### PR TITLE
Generate copy of CRD manifests under manifests/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: controller-gen kustomize ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(KUSTOMIZE) build config/crd > manifests/application-api-customresourcedefinitions.yaml
 	$(MAKE) manifests-kcp
 
 manifests-kcp:	## Generate KCP APIResourceSchema from CRDs

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -1,0 +1,1694 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: applicationpromotionruns.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: ApplicationPromotionRun
+    listKind: ApplicationPromotionRunList
+    plural: applicationpromotionruns
+    shortNames:
+    - apr
+    - promotion
+    singular: applicationpromotionrun
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ApplicationPromotionRun is the Schema for the applicationpromotionruns
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ApplicationPromotionRunSpec defines the desired state of
+              ApplicationPromotionRun
+            properties:
+              application:
+                description: Application is the name of an Application resource defined
+                  within the namespaced, and which is the target of the promotion
+                type: string
+              automatedPromotion:
+                description: 'AutomatedPromotion is for fields specific to automated
+                  promotion Only one field should be defined: either ''manualPromotion''
+                  or ''automatedPromotion'', but not both.'
+                properties:
+                  initialEnvironment:
+                    description: 'InitialEnvironment: start iterating through the
+                      digraph, beginning with the value specified in ''initialEnvironment'''
+                    type: string
+                required:
+                - initialEnvironment
+                type: object
+              manualPromotion:
+                description: 'ManualPromotion is for fields specific to manual promotion.
+                  Only one field should be defined: either ''manualPromotion'' or
+                  ''automatedPromotion'', but not both.'
+                properties:
+                  targetEnvironment:
+                    description: TargetEnvironment is the environment to promote to
+                    type: string
+                required:
+                - targetEnvironment
+                type: object
+              snapshot:
+                description: Snapshot refers to the name of a Snapshot resource defined
+                  within the namespace, used to promote container images between Environments.
+                type: string
+            required:
+            - application
+            - snapshot
+            type: object
+          status:
+            description: ApplicationPromotionRunStatus defines the observed state
+              of ApplicationPromotionRun
+            properties:
+              activeBindings:
+                description: 'ActiveBindings is the list of active bindings currently
+                  being promoted to: - For an automated promotion, there can be multiple
+                  active bindings at a time (one for each env at a particular tree
+                  depth) - For a manual promotion, there will be only one.'
+                items:
+                  type: string
+                type: array
+              completionResult:
+                description: CompletionResult indicates success/failure once the promotion
+                  has completed all work. CompletionResult will only have a value
+                  if State field is 'Complete'.
+                type: string
+              environmentStatus:
+                description: EnvironmentStatus represents the set of steps taken during
+                  the  current promotion
+                items:
+                  description: 'PromotionRunEnvironmentStatus represents the set of
+                    steps taken during the  current promotion: - manual promotions
+                    will only have a single step. - automated promotions may have
+                    one or more steps, depending on how many environments have been
+                    promoted to.'
+                  properties:
+                    displayStatus:
+                      description: DisplayStatus is human-readible description of
+                        the current state/status.
+                      type: string
+                    environmentName:
+                      description: EnvironmentName is the name of the environment
+                        that was promoted to in this step
+                      type: string
+                    status:
+                      description: Status is/was the result of promoting to that environment.
+                      type: string
+                    step:
+                      description: Step is the sequential number of the step in the
+                        array, starting with 1
+                      type: integer
+                  required:
+                  - displayStatus
+                  - environmentName
+                  - status
+                  - step
+                  type: object
+                type: array
+              state:
+                description: State indicates whether or not the overall promotion
+                  (either manual or automated is complete)
+                type: string
+            required:
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: applications.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    shortNames:
+    - hasapp
+    - ha
+    - app
+    singular: application
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Application is the Schema for the applications API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ApplicationSpec defines the desired state of Application
+            properties:
+              appModelRepository:
+                description: AppModelRepository refers to the git repository that
+                  will store the application model (a devfile) Can be the same as
+                  GitOps repository. A repository will be generated if this field
+                  is left blank.
+                properties:
+                  branch:
+                    description: Branch corresponds to the branch in the repository
+                      that should be used
+                    type: string
+                  context:
+                    description: Context corresponds to the context within the repository
+                      that should be used
+                    type: string
+                  url:
+                    description: URL refers to the repository URL that should be used.
+                    type: string
+                required:
+                - url
+                type: object
+              description:
+                description: Description refers to a brief description of the application.
+                type: string
+              displayName:
+                description: DisplayName refers to the name that an application will
+                  be deployed with in App Studio.
+                type: string
+              gitOpsRepository:
+                description: GitOpsRepository refers to the git repository that will
+                  store the gitops resources. Can be the same as App Model Repository.
+                  A repository will be generated if this field is left blank.
+                properties:
+                  branch:
+                    description: Branch corresponds to the branch in the repository
+                      that should be used
+                    type: string
+                  context:
+                    description: Context corresponds to the context within the repository
+                      that should be used
+                    type: string
+                  url:
+                    description: URL refers to the repository URL that should be used.
+                    type: string
+                required:
+                - url
+                type: object
+            required:
+            - displayName
+            type: object
+          status:
+            description: ApplicationStatus defines the observed state of Application
+            properties:
+              conditions:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              devfile:
+                description: Devfile corresponds to the devfile representation of
+                  the Application resource
+                type: string
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: applicationsnapshotenvironmentbindings.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: ApplicationSnapshotEnvironmentBinding
+    listKind: ApplicationSnapshotEnvironmentBindingList
+    plural: applicationsnapshotenvironmentbindings
+    shortNames:
+    - aseb
+    - binding
+    singular: applicationsnapshotenvironmentbinding
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ApplicationSnapshotEnvironmentBinding is the Schema for the applicationsnapshotenvironmentbindings
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ApplicationSnapshotEnvironmentBindingSpec defines the desired
+              state of ApplicationSnapshotEnvironmentBinding
+            properties:
+              application:
+                description: Application is a reference to the Application resource
+                  (defined in the namespace) involved in the binding
+                type: string
+              components:
+                description: Components contains individual component data
+                items:
+                  description: BindingComponent contains individual component data
+                  properties:
+                    configuration:
+                      description: Configuration describes GitOps repository customizations
+                        that are specific to the the component-application-environment
+                        combination. - Values defined in this struct will overwrite
+                        values from Application/Environment/Component
+                      properties:
+                        env:
+                          description: Env describes environment variables to use
+                            for the component
+                          items:
+                            description: EnvVarPair describes environment variables
+                              to use for the component
+                            properties:
+                              name:
+                                description: Name is the environment variable name
+                                type: string
+                              value:
+                                description: Value is the environment variable value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        replicas:
+                          description: Replicas defines the number of replicas to
+                            use for the component
+                          type: integer
+                        resources:
+                          description: Resources defines the Compute Resources required
+                            by the component
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      required:
+                      - replicas
+                      type: object
+                    name:
+                      description: Name is the name of the component.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              environment:
+                description: Environment is the Environment resource (defined in the
+                  namespace) that the binding will deploy to
+                type: string
+              snapshot:
+                description: Snapshot is the Snapshot resource (defined in the namespace)
+                  that contains the container image versions for the components of
+                  the Application
+                type: string
+            required:
+            - application
+            - components
+            - environment
+            - snapshot
+            type: object
+          status:
+            description: ApplicationSnapshotEnvironmentBindingStatus defines the observed
+              state of ApplicationSnapshotEnvironmentBinding
+            properties:
+              components:
+                description: Components describes a component's GitOps repository
+                  information. This status is updated by the Application Service controller.
+                items:
+                  description: ComponentStatus contains the status of the components
+                  properties:
+                    gitopsRepository:
+                      description: GitOpsRepository contains the Git URL, path, branch,
+                        and most recent commit id for the component
+                      properties:
+                        branch:
+                          description: Branch is the branch to use when accessing
+                            the GitOps repository
+                          type: string
+                        commitID:
+                          description: CommitID contains the most recent commit ID
+                            for which the Kubernetes resources of the Component were
+                            modified.
+                          type: string
+                        generatedResources:
+                          description: GeneratedResources contains the list of GitOps
+                            repository resources generated by the application service
+                            controller in the overlays/<environment> dir, for example,
+                            'deployment-patch.yaml'. This is stored to differentiate
+                            between application-service controller generated resources
+                            vs resources added by a user
+                          items:
+                            type: string
+                          type: array
+                        path:
+                          description: 'Path is a pointer to a folder in the GitOps
+                            repo, containing a kustomization.yaml NOTE: Each component-env
+                            combination must have it''s own separate path'
+                          type: string
+                        url:
+                          description: URL is the Git repository URL e.g. The Git
+                            repository that contains the K8s resources to deployment
+                            for the component of the application.
+                          type: string
+                      required:
+                      - branch
+                      - commitID
+                      - generatedResources
+                      - path
+                      - url
+                      type: object
+                    name:
+                      description: Name is the name of the component.
+                      type: string
+                  required:
+                  - gitopsRepository
+                  - name
+                  type: object
+                type: array
+              gitopsDeployments:
+                description: GitOpsDeployments describes the set of GitOpsDeployment
+                  resources that correspond to the binding. To determine the health/sync
+                  status of a binding, you can look at the GitOpsDeployments decribed
+                  here.
+                items:
+                  description: "BindingStatusGitOpsDeployment describes an individual
+                    reference to a GitOpsDeployment resources that is used to deploy
+                    this binding. \n To determine the health/sync status of a binding,
+                    you can look at the GitOpsDeployments decribed here."
+                  properties:
+                    componentName:
+                      description: ComponentName is the name of the component in the
+                        (component, gitopsdeployment) pair
+                      type: string
+                    gitopsDeployment:
+                      description: GitOpsDeployment is a reference to the name of
+                        a GitOpsDeployment resource which is used to deploy the binding.
+                        The Health/sync status for the binding can thus be read from
+                        the references GitOpsDEployment
+                      type: string
+                  required:
+                  - componentName
+                  type: object
+                type: array
+              gitopsRepoConditions:
+                description: Condition describes operations on the GitOps repository,
+                  for example, if there were issues with generating/processing the
+                  repository. This status is updated by the Application Service controller.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: applicationsnapshots.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: ApplicationSnapshot
+    listKind: ApplicationSnapshotList
+    plural: applicationsnapshots
+    shortNames:
+    - as
+    - snapshot
+    singular: applicationsnapshot
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ApplicationSnapshot is the Schema for the applicationsnapshots
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ApplicationSnapshotSpec defines the desired state of ApplicationSnapshot
+            properties:
+              application:
+                description: Application is a reference to the name of an Application
+                  resource within the same namespace, which defines the target application
+                  for the Snapshot (when used with a Binding).
+                type: string
+              artifacts:
+                description: Artifacts is a placeholder section for 'artifact links'
+                  we want to maintain to other AppStudio resources. See Environment
+                  API doc for details.
+                properties:
+                  unstableFields:
+                    description: 'NOTE: This field (and struct) are placeholders.
+                      - Until this API is stabilized, consumers of the API may store
+                      any unstructured JSON/YAML data here,   but no backwards compatibility
+                      will be preserved.'
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              components:
+                description: Components field contains the sets of components to deploy
+                  as part of this snapshot.
+                items:
+                  description: ApplicationSnapshotComponent
+                  properties:
+                    containerImage:
+                      description: ContainerImage is the container image to use when
+                        deploying the component, as part of a Snapshot
+                      type: string
+                    name:
+                      description: Name is the name of the component
+                      type: string
+                  required:
+                  - containerImage
+                  - name
+                  type: object
+                type: array
+              displayDescription:
+                description: DisplayDescription is a user-visible, user definable
+                  description for the resource (and is not used for any functional
+                  behaviour)
+                type: string
+              displayName:
+                description: DisplayName is a user-visible, user-definable name for
+                  the resource (and is not used for any functional behaviour)
+                type: string
+            required:
+            - application
+            type: object
+          status:
+            description: ApplicationSnapshotStatus defines the observed state of ApplicationSnapshot
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  for the Snapshot
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: componentdetectionqueries.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: ComponentDetectionQuery
+    listKind: ComponentDetectionQueryList
+    plural: componentdetectionqueries
+    shortNames:
+    - hcdq
+    - compdetection
+    singular: componentdetectionquery
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ComponentDetectionQuery is the Schema for the componentdetectionqueries
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ComponentDetectionQuerySpec defines the desired state of
+              ComponentDetectionQuery
+            properties:
+              git:
+                description: Git Source for a Component
+                properties:
+                  context:
+                    description: A relative path inside the git repo containing the
+                      component
+                    type: string
+                  devfileUrl:
+                    description: If specified, the devfile at the URL will be used
+                      for the component.
+                    type: string
+                  dockerfileUrl:
+                    description: If specified, the dockerfile at the URL will be used
+                      for the component.
+                    type: string
+                  revision:
+                    description: Specify a branch/tag/commit id. If not specified,
+                      default is `main`/`master`.
+                    type: string
+                  url:
+                    description: If importing from git, the repository to create the
+                      component from
+                    type: string
+                required:
+                - url
+                type: object
+              secret:
+                description: Secret describes the name of a Kubernetes secret containing
+                  a Personal Access Token to access the git repostiory
+                type: string
+            required:
+            - git
+            type: object
+          status:
+            description: ComponentDetectionQueryStatus defines the observed state
+              of ComponentDetectionQuery
+            properties:
+              componentDetected:
+                additionalProperties:
+                  description: ComponentDetectionDescription holds all the information
+                    about the component being detected
+                  properties:
+                    componentStub:
+                      description: ComponentStub is a stub of the component detected
+                        with all the info gathered from the devfile or service detection
+                      properties:
+                        application:
+                          description: Application to add the component to
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        componentName:
+                          description: ComponentName is name of the component to be
+                            added to the HASApplication
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        containerImage:
+                          description: The container image to build or create the
+                            component from
+                          type: string
+                        env:
+                          description: An array of environment variables to add to
+                            the component
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        replicas:
+                          description: The number of replicas to deploy the component
+                            with
+                          type: integer
+                        resources:
+                          description: Compute Resources required by this component
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        route:
+                          description: The route to expose the component with
+                          type: string
+                        secret:
+                          description: 'Secret describes the name of a Kubernetes
+                            secret containing either: 1. A Personal Access Token to
+                            access the Component''s git repostiory (if using a Git-source
+                            component) or 2. An Image Pull Secret to access the Component''s
+                            container image (if using an Image-source component).'
+                          type: string
+                        skipGitOpsResourceGeneration:
+                          description: Whether or not to bypass the generation of
+                            GitOps resources for the Component. Defaults to false.
+                          type: boolean
+                        source:
+                          description: Source describes the Component source
+                          properties:
+                            git:
+                              description: Git Source for a Component
+                              properties:
+                                context:
+                                  description: A relative path inside the git repo
+                                    containing the component
+                                  type: string
+                                devfileUrl:
+                                  description: If specified, the devfile at the URL
+                                    will be used for the component.
+                                  type: string
+                                dockerfileUrl:
+                                  description: If specified, the dockerfile at the
+                                    URL will be used for the component.
+                                  type: string
+                                revision:
+                                  description: Specify a branch/tag/commit id. If
+                                    not specified, default is `main`/`master`.
+                                  type: string
+                                url:
+                                  description: If importing from git, the repository
+                                    to create the component from
+                                  type: string
+                              required:
+                              - url
+                              type: object
+                          type: object
+                        targetPort:
+                          description: The port to expose the component over
+                          type: integer
+                      required:
+                      - application
+                      - componentName
+                      type: object
+                    devfileFound:
+                      description: DevfileFound tells if a devfile is found in the
+                        component
+                      type: boolean
+                    language:
+                      description: Language specifies the language of the component
+                        detected
+                      type: string
+                    projectType:
+                      description: ProjectType specifies the type of project for the
+                        component detected
+                      type: string
+                  type: object
+                description: ComponentDetected gives a list of components and the
+                  info from detection
+                type: object
+              conditions:
+                description: Condition about the Component CR
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: components.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: Component
+    listKind: ComponentList
+    plural: components
+    shortNames:
+    - hascmp
+    - hc
+    - comp
+    singular: component
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Component is the Schema for the components API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ComponentSpec defines the desired state of Component
+            properties:
+              application:
+                description: Application to add the component to
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              componentName:
+                description: ComponentName is name of the component to be added to
+                  the HASApplication
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              containerImage:
+                description: The container image to build or create the component
+                  from
+                type: string
+              env:
+                description: An array of environment variables to add to the component
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previously defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              replicas:
+                description: The number of replicas to deploy the component with
+                type: integer
+              resources:
+                description: Compute Resources required by this component
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              route:
+                description: The route to expose the component with
+                type: string
+              secret:
+                description: 'Secret describes the name of a Kubernetes secret containing
+                  either: 1. A Personal Access Token to access the Component''s git
+                  repostiory (if using a Git-source component) or 2. An Image Pull
+                  Secret to access the Component''s container image (if using an Image-source
+                  component).'
+                type: string
+              skipGitOpsResourceGeneration:
+                description: Whether or not to bypass the generation of GitOps resources
+                  for the Component. Defaults to false.
+                type: boolean
+              source:
+                description: Source describes the Component source
+                properties:
+                  git:
+                    description: Git Source for a Component
+                    properties:
+                      context:
+                        description: A relative path inside the git repo containing
+                          the component
+                        type: string
+                      devfileUrl:
+                        description: If specified, the devfile at the URL will be
+                          used for the component.
+                        type: string
+                      dockerfileUrl:
+                        description: If specified, the dockerfile at the URL will
+                          be used for the component.
+                        type: string
+                      revision:
+                        description: Specify a branch/tag/commit id. If not specified,
+                          default is `main`/`master`.
+                        type: string
+                      url:
+                        description: If importing from git, the repository to create
+                          the component from
+                        type: string
+                    required:
+                    - url
+                    type: object
+                type: object
+              targetPort:
+                description: The port to expose the component over
+                type: integer
+            required:
+            - application
+            - componentName
+            type: object
+          status:
+            description: ComponentStatus defines the observed state of Component
+            properties:
+              conditions:
+                description: Condition about the Component CR
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              containerImage:
+                description: ContainerImage stores the associated built container
+                  image for the component
+                type: string
+              devfile:
+                description: The devfile model for the Component CR
+                type: string
+              gitops:
+                description: GitOps specific status for the Component CR
+                properties:
+                  branch:
+                    description: Branch is the branch used for the gitops repository
+                    type: string
+                  commitID:
+                    description: CommitID is the most recent commit ID in the GitOps
+                      repository for this component
+                    type: string
+                  context:
+                    description: Context is the path within the gitops repository
+                      used for the gitops resources
+                    type: string
+                  repositoryURL:
+                    description: RepositoryURL is the gitops repository URL for the
+                      component
+                    type: string
+                  resourceGenerationSkipped:
+                    description: ResourceGenerationSkipped is whether or not GitOps
+                      resource generation was skipped for the component
+                    type: boolean
+                type: object
+              webhook:
+                description: Webhook URL generated by Builds
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: environments.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: Environment
+    listKind: EnvironmentList
+    plural: environments
+    shortNames:
+    - env
+    singular: environment
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Environment is the Schema for the environments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EnvironmentSpec defines the desired state of Environment
+            properties:
+              configuration:
+                description: Configuration contains environment-specific details for
+                  Applications/Components that are deployed to the Environment.
+                properties:
+                  env:
+                    description: Env is an array of standard environment vairables
+                    items:
+                      description: EnvVarPair describes environment variables to use
+                        for the component
+                      properties:
+                        name:
+                          description: Name is the environment variable name
+                          type: string
+                        value:
+                          description: Value is the environment variable value
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                required:
+                - env
+                type: object
+              deploymentStrategy:
+                description: DeploymentStrategy is the promotion strategy for the
+                  Environment See Environment API doc for details.
+                type: string
+              displayName:
+                description: DisplayName is the user-visible, user-definable name
+                  for the environment (but not used for functional requirements)
+                type: string
+              parentEnvironment:
+                description: 'ParentEnvironment references another Environment defined
+                  in the namespace: when automated promotion is enabled, promotions
+                  to the parent environment will cause this environment to be promoted
+                  to. See Environment API doc for details.'
+                type: string
+              tags:
+                description: Tags are a user-visisble, user-definable set of tags
+                  that can be applied to the environment
+                items:
+                  type: string
+                type: array
+              type:
+                description: Type is whether the Environment is a POC or non-POC environment
+                type: string
+              unstableConfigurationFields:
+                description: 'UnstableConfigurationFields are experimental/prototype:
+                  the API has not been finalized here, and is subject to breaking
+                  changes. See comment on UnstableEnvironmentConfiguration for details.'
+                properties:
+                  kubernetesCredentials:
+                    description: "KubernetesClusterCredentials allows you to specify
+                      cluster credentials for stanadard K8s cluster (e.g. non-KCP
+                      workspace). \n See this temporary URL for details on what values
+                      to provide for the APIURL and Secret: https://github.com/redhat-appstudio/managed-gitops/tree/main/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource"
+                    properties:
+                      apiURL:
+                        description: APIURL is a reference to a cluster API url defined
+                          within the kube config file of the cluster credentials secret.
+                        type: string
+                      clusterCredentialsSecret:
+                        description: "ClusterCredentialsSecret is a reference to the
+                          name of k8s Secret, defined within the same namespace as
+                          the Environment resource, that contains a kubeconfig. The
+                          Secret must be of type 'managed-gitops.redhat.com/managed-environment'
+                          \n See this temporary URL for details: https://github.com/redhat-appstudio/managed-gitops/tree/main/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource"
+                        type: string
+                      targetNamespace:
+                        description: TargetNamespace is the default destination target
+                          on the cluster for deployments. This Namespace will be used
+                          for any GitOps repository K8s resources where the `.metadata.Namespace`
+                          field is not specified.
+                        type: string
+                    required:
+                    - apiURL
+                    - clusterCredentialsSecret
+                    - targetNamespace
+                    type: object
+                type: object
+            required:
+            - deploymentStrategy
+            - displayName
+            - type
+            type: object
+          status:
+            description: EnvironmentStatus defines the observed state of Environment
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
In order to set up the controller tests for HAS to use this repository, we need to point the test code to a single CRD manifest file containing all of the CRDs. 

I just copied what was done in `managed-gitops/appstudio-shared` originally and updated the `make manifest` target to also generate a single, combined CRD manifest file under `manifests/`