### PR TITLE
[DEVHAS-49]Add additional fields to CRDs get output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .tmp/
 bin/
+.vscode
 cover.out

--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -74,6 +74,9 @@ type ApplicationStatus struct {
 // Application is the Schema for the applications API
 // +kubebuilder:resource:path=applications,shortName=hasapp;ha;app
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[0].reason"
 type Application struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -75,8 +75,8 @@ type ApplicationStatus struct {
 // +kubebuilder:resource:path=applications,shortName=hasapp;ha;app
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status"
-// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[0].reason"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[-1].status"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[-1].reason"
 type Application struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -151,6 +151,9 @@ type GitOpsStatus struct {
 
 // Component is the Schema for the components API
 // +kubebuilder:resource:path=components,shortName=hascmp;hc;comp
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[0].reason"
 type Component struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -154,6 +154,7 @@ type GitOpsStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[-1].status"
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[-1].reason"
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".status.conditions[-1].type"
 type Component struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -152,8 +152,8 @@ type GitOpsStatus struct {
 // Component is the Schema for the components API
 // +kubebuilder:resource:path=components,shortName=hascmp;hc;comp
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status"
-// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[0].reason"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[-1].status"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[-1].reason"
 type Component struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/componentdetectionquery_types.go
+++ b/api/v1alpha1/componentdetectionquery_types.go
@@ -72,6 +72,7 @@ type ComponentDetectionQueryStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[-1].status"
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[-1].reason"
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".status.conditions[-1].type"
 type ComponentDetectionQuery struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/componentdetectionquery_types.go
+++ b/api/v1alpha1/componentdetectionquery_types.go
@@ -69,6 +69,9 @@ type ComponentDetectionQueryStatus struct {
 
 // ComponentDetectionQuery is the Schema for the componentdetectionqueries API
 // +kubebuilder:resource:path=componentdetectionqueries,shortName=hcdq;compdetection
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[-1].status"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[-1].reason"
 type ComponentDetectionQuery struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/appstudio.redhat.com_applications.yaml
+++ b/config/crd/bases/appstudio.redhat.com_applications.yaml
@@ -178,6 +178,11 @@ spec:
     storage: true
     subresources:
       status: {}
+additionalPrinterColumns:
+  - name: Status
+    type: array
+    description: The status of application
+    jsonPath: .status.conditions
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/appstudio.redhat.com_applications.yaml
+++ b/config/crd/bases/appstudio.redhat.com_applications.yaml
@@ -178,11 +178,6 @@ spec:
     storage: true
     subresources:
       status: {}
-additionalPrinterColumns:
-  - name: Status
-    type: array
-    description: The status of application
-    jsonPath: .status.conditions
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/appstudio.redhat.com_applications.yaml
+++ b/config/crd/bases/appstudio.redhat.com_applications.yaml
@@ -24,10 +24,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .status.conditions[0].status
+    - jsonPath: .status.conditions[-1].status
       name: Status
       type: string
-    - jsonPath: .status.conditions[0].reason
+    - jsonPath: .status.conditions[-1].reason
       name: Reason
       type: string
     name: v1alpha1

--- a/config/crd/bases/appstudio.redhat.com_applications.yaml
+++ b/config/crd/bases/appstudio.redhat.com_applications.yaml
@@ -20,7 +20,17 @@ spec:
     singular: application
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[0].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Application is the Schema for the applications API

--- a/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
+++ b/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
@@ -19,7 +19,17 @@ spec:
     singular: componentdetectionquery
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[-1].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[-1].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ComponentDetectionQuery is the Schema for the componentdetectionqueries

--- a/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
+++ b/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .status.conditions[-1].reason
       name: Reason
       type: string
+    - jsonPath: .status.conditions[-1].type
+      name: Type
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/appstudio.redhat.com_components.yaml
+++ b/config/crd/bases/appstudio.redhat.com_components.yaml
@@ -349,6 +349,19 @@ spec:
         required:
         - spec
         type: object
+    additionalPrinterColumns:
+      - name: Age
+        jsonPath: .metadata.creationTimestamp
+        description: The age of this resource
+        type: date
+      - name: Type
+        type: string
+        description: The type of component condition
+        jsonPath: .status.conditions[0].type
+      - name: Status
+        type: string
+        description: The status of component
+        jsonPath: .status.conditions[0].status
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/appstudio.redhat.com_components.yaml
+++ b/config/crd/bases/appstudio.redhat.com_components.yaml
@@ -30,6 +30,9 @@ spec:
     - jsonPath: .status.conditions[-1].reason
       name: Reason
       type: string
+    - jsonPath: .status.conditions[-1].type
+      name: Type
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/appstudio.redhat.com_components.yaml
+++ b/config/crd/bases/appstudio.redhat.com_components.yaml
@@ -24,10 +24,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .status.conditions[0].status
+    - jsonPath: .status.conditions[-1].status
       name: Status
       type: string
-    - jsonPath: .status.conditions[0].reason
+    - jsonPath: .status.conditions[-1].reason
       name: Reason
       type: string
     name: v1alpha1

--- a/config/crd/bases/appstudio.redhat.com_components.yaml
+++ b/config/crd/bases/appstudio.redhat.com_components.yaml
@@ -20,7 +20,17 @@ spec:
     singular: component
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[0].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Component is the Schema for the components API
@@ -349,19 +359,6 @@ spec:
         required:
         - spec
         type: object
-    additionalPrinterColumns:
-      - name: Age
-        jsonPath: .metadata.creationTimestamp
-        description: The age of this resource
-        type: date
-      - name: Type
-        type: string
-        description: The type of component condition
-        jsonPath: .status.conditions[0].type
-      - name: Status
-        type: string
-        description: The status of component
-        jsonPath: .status.conditions[0].status
     served: true
     storage: true
     subresources:

--- a/config/kcp/apiexport.yaml
+++ b/config/kcp/apiexport.yaml
@@ -14,10 +14,10 @@ spec:
   - group: ""
     resource: "configmaps"
   latestResourceSchemas:
-    - v202211092111.applications.appstudio.redhat.com
-    - v202211092111.componentdetectionqueries.appstudio.redhat.com
-    - v202211092111.components.appstudio.redhat.com
-    - v202211092111.environments.appstudio.redhat.com
-    - v202211092111.promotionruns.appstudio.redhat.com
-    - v202211092111.snapshotenvironmentbindings.appstudio.redhat.com
-    - v202211092111.snapshots.appstudio.redhat.com
+    - v202211101622.applications.appstudio.redhat.com
+    - v202211101622.componentdetectionqueries.appstudio.redhat.com
+    - v202211101622.components.appstudio.redhat.com
+    - v202211101622.environments.appstudio.redhat.com
+    - v202211101622.promotionruns.appstudio.redhat.com
+    - v202211101622.snapshotenvironmentbindings.appstudio.redhat.com
+    - v202211101622.snapshots.appstudio.redhat.com

--- a/config/kcp/apiresourceschema.yaml
+++ b/config/kcp/apiresourceschema.yaml
@@ -19,7 +19,17 @@ spec:
     singular: application
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[0].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       description: Application is the Schema for the applications API
       properties:
@@ -194,7 +204,17 @@ spec:
     singular: componentdetectionquery
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[-1].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[-1].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       description: ComponentDetectionQuery is the Schema for the componentdetectionqueries
         API
@@ -584,7 +604,17 @@ spec:
     singular: component
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[0].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       description: Component is the Schema for the components API
       properties:

--- a/config/kcp/apiresourceschema.yaml
+++ b/config/kcp/apiresourceschema.yaml
@@ -191,10 +191,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-<<<<<<< HEAD
   name: v202211092111.componentdetectionqueries.appstudio.redhat.com
-=======
-  name: v202211021841.applicationsnapshotenvironmentbindings.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -486,7 +483,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202211021841.applicationsnapshots.appstudio.redhat.com
+  name: v202211031948.applicationsnapshots.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -651,8 +648,12 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
+<<<<<<< HEAD
   name: v202211021841.componentdetectionqueries.appstudio.redhat.com
 >>>>>>> 8f9ce71 (add type to cdq)
+=======
+  name: v202211031948.componentdetectionqueries.appstudio.redhat.com
+>>>>>>> d48d4ac (add type to component printer column)
 spec:
   group: appstudio.redhat.com
   names:
@@ -1055,10 +1056,14 @@ kind: APIResourceSchema
 metadata:
   creationTimestamp: null
 <<<<<<< HEAD
+<<<<<<< HEAD
   name: v202211092111.components.appstudio.redhat.com
 =======
   name: v202211021841.components.appstudio.redhat.com
 >>>>>>> 8f9ce71 (add type to cdq)
+=======
+  name: v202211031948.components.appstudio.redhat.com
+>>>>>>> d48d4ac (add type to component printer column)
 spec:
   group: appstudio.redhat.com
   names:
@@ -1081,6 +1086,9 @@ spec:
       type: string
     - jsonPath: .status.conditions[-1].reason
       name: Reason
+      type: string
+    - jsonPath: .status.conditions[-1].type
+      name: Type
       type: string
     name: v1alpha1
     schema:
@@ -1420,10 +1428,14 @@ kind: APIResourceSchema
 metadata:
   creationTimestamp: null
 <<<<<<< HEAD
+<<<<<<< HEAD
   name: v202211092111.environments.appstudio.redhat.com
 =======
   name: v202211021841.environments.appstudio.redhat.com
 >>>>>>> 8f9ce71 (add type to cdq)
+=======
+  name: v202211031948.environments.appstudio.redhat.com
+>>>>>>> d48d4ac (add type to component printer column)
 spec:
   group: appstudio.redhat.com
   names:

--- a/config/kcp/apiresourceschema.yaml
+++ b/config/kcp/apiresourceschema.yaml
@@ -191,6 +191,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
+<<<<<<< HEAD
   name: v202211092111.componentdetectionqueries.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
@@ -648,12 +649,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-<<<<<<< HEAD
   name: v202211021841.componentdetectionqueries.appstudio.redhat.com
->>>>>>> 8f9ce71 (add type to cdq)
-=======
-  name: v202211031948.componentdetectionqueries.appstudio.redhat.com
->>>>>>> d48d4ac (add type to component printer column)
 spec:
   group: appstudio.redhat.com
   names:
@@ -1055,15 +1051,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-<<<<<<< HEAD
-<<<<<<< HEAD
   name: v202211092111.components.appstudio.redhat.com
-=======
-  name: v202211021841.components.appstudio.redhat.com
->>>>>>> 8f9ce71 (add type to cdq)
-=======
-  name: v202211031948.components.appstudio.redhat.com
->>>>>>> d48d4ac (add type to component printer column)
 spec:
   group: appstudio.redhat.com
   names:
@@ -1427,15 +1415,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-<<<<<<< HEAD
-<<<<<<< HEAD
   name: v202211092111.environments.appstudio.redhat.com
-=======
-  name: v202211021841.environments.appstudio.redhat.com
->>>>>>> 8f9ce71 (add type to cdq)
-=======
-  name: v202211031948.environments.appstudio.redhat.com
->>>>>>> d48d4ac (add type to component printer column)
 spec:
   group: appstudio.redhat.com
   names:

--- a/config/kcp/apiresourceschema.yaml
+++ b/config/kcp/apiresourceschema.yaml
@@ -1054,9 +1054,6 @@ metadata:
   creationTimestamp: null
   name: v202211092111.promotionruns.appstudio.redhat.com
 spec:
-  group: appstudio.redhat.com
-  names:
-    kind: PromotionRun
     listKind: PromotionRunList
     plural: promotionruns
     shortNames:
@@ -1587,9 +1584,6 @@ metadata:
   creationTimestamp: null
   name: v202211092111.snapshots.appstudio.redhat.com
 spec:
-  group: appstudio.redhat.com
-  names:
-    kind: Snapshot
     listKind: SnapshotList
     plural: snapshots
     shortNames:

--- a/config/kcp/apiresourceschema.yaml
+++ b/config/kcp/apiresourceschema.yaml
@@ -5,7 +5,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202211092111.applications.appstudio.redhat.com
+  name: v202211101622.applications.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -191,465 +191,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-<<<<<<< HEAD
-  name: v202211092111.componentdetectionqueries.appstudio.redhat.com
-spec:
-  group: appstudio.redhat.com
-  names:
-    kind: ApplicationSnapshotEnvironmentBinding
-    listKind: ApplicationSnapshotEnvironmentBindingList
-    plural: applicationsnapshotenvironmentbindings
-    shortNames:
-    - aseb
-    - binding
-    singular: applicationsnapshotenvironmentbinding
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      description: ApplicationSnapshotEnvironmentBinding is the Schema for the applicationsnapshotenvironmentbindings
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ApplicationSnapshotEnvironmentBindingSpec defines the desired
-            state of ApplicationSnapshotEnvironmentBinding
-          properties:
-            application:
-              description: Application is a reference to the Application resource
-                (defined in the namespace) involved in the binding
-              type: string
-            components:
-              description: Components contains individual component data
-              items:
-                description: BindingComponent contains individual component data
-                properties:
-                  configuration:
-                    description: Configuration describes GitOps repository customizations
-                      that are specific to the the component-application-environment
-                      combination. - Values defined in this struct will overwrite
-                      values from Application/Environment/Component
-                    properties:
-                      env:
-                        description: Env describes environment variables to use for
-                          the component
-                        items:
-                          description: EnvVarPair describes environment variables
-                            to use for the component
-                          properties:
-                            name:
-                              description: Name is the environment variable name
-                              type: string
-                            value:
-                              description: Value is the environment variable value
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      replicas:
-                        description: Replicas defines the number of replicas to use
-                          for the component
-                        type: integer
-                      resources:
-                        description: Resources defines the Compute Resources required
-                          by the component
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    required:
-                    - replicas
-                    type: object
-                  name:
-                    description: Name is the name of the component.
-                    type: string
-                required:
-                - name
-                type: object
-              type: array
-            environment:
-              description: Environment is the Environment resource (defined in the
-                namespace) that the binding will deploy to
-              type: string
-            snapshot:
-              description: Snapshot is the Snapshot resource (defined in the namespace)
-                that contains the container image versions for the components of the
-                Application
-              type: string
-          required:
-          - application
-          - components
-          - environment
-          - snapshot
-          type: object
-        status:
-          description: ApplicationSnapshotEnvironmentBindingStatus defines the observed
-            state of ApplicationSnapshotEnvironmentBinding
-          properties:
-            components:
-              description: Components describes a component's GitOps repository information.
-                This status is updated by the Application Service controller.
-              items:
-                description: ComponentStatus contains the status of the components
-                properties:
-                  gitopsRepository:
-                    description: GitOpsRepository contains the Git URL, path, branch,
-                      and most recent commit id for the component
-                    properties:
-                      branch:
-                        description: Branch is the branch to use when accessing the
-                          GitOps repository
-                        type: string
-                      commitID:
-                        description: CommitID contains the most recent commit ID for
-                          which the Kubernetes resources of the Component were modified.
-                        type: string
-                      generatedResources:
-                        description: GeneratedResources contains the list of GitOps
-                          repository resources generated by the application service
-                          controller in the overlays/<environment> dir, for example,
-                          'deployment-patch.yaml'. This is stored to differentiate
-                          between application-service controller generated resources
-                          vs resources added by a user
-                        items:
-                          type: string
-                        type: array
-                      path:
-                        description: 'Path is a pointer to a folder in the GitOps
-                          repo, containing a kustomization.yaml NOTE: Each component-env
-                          combination must have it''s own separate path'
-                        type: string
-                      url:
-                        description: URL is the Git repository URL e.g. The Git repository
-                          that contains the K8s resources to deployment for the component
-                          of the application.
-                        type: string
-                    required:
-                    - branch
-                    - commitID
-                    - generatedResources
-                    - path
-                    - url
-                    type: object
-                  name:
-                    description: Name is the name of the component.
-                    type: string
-                required:
-                - gitopsRepository
-                - name
-                type: object
-              type: array
-            gitopsDeployments:
-              description: GitOpsDeployments describes the set of GitOpsDeployment
-                resources that correspond to the binding. To determine the health/sync
-                status of a binding, you can look at the GitOpsDeployments decribed
-                here.
-              items:
-                description: "BindingStatusGitOpsDeployment describes an individual
-                  reference to a GitOpsDeployment resources that is used to deploy
-                  this binding. \n To determine the health/sync status of a binding,
-                  you can look at the GitOpsDeployments decribed here."
-                properties:
-                  componentName:
-                    description: ComponentName is the name of the component in the
-                      (component, gitopsdeployment) pair
-                    type: string
-                  gitopsDeployment:
-                    description: GitOpsDeployment is a reference to the name of a
-                      GitOpsDeployment resource which is used to deploy the binding.
-                      The Health/sync status for the binding can thus be read from
-                      the references GitOpsDEployment
-                    type: string
-                required:
-                - componentName
-                type: object
-              type: array
-            gitopsRepoConditions:
-              description: Condition describes operations on the GitOps repository,
-                for example, if there were issues with generating/processing the repository.
-                This status is updated by the Application Service controller.
-              items:
-                description: "Condition contains details for one aspect of the current
-                  state of this API Resource. --- This struct is intended for direct
-                  use as an array at the field path .status.conditions.  For example,
-                  type FooStatus struct{     // Represents the observations of a foo's
-                  current state.     // Known .status.conditions.type are: \"Available\",
-                  \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     //
-                  +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                  \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                  patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                  \n     // other fields }"
-                properties:
-                  lastTransitionTime:
-                    description: lastTransitionTime is the last time the condition
-                      transitioned from one status to another. This should be when
-                      the underlying condition changed.  If that is not known, then
-                      using the time when the API field changed is acceptable.
-                    format: date-time
-                    type: string
-                  message:
-                    description: message is a human readable message indicating details
-                      about the transition. This may be an empty string.
-                    maxLength: 32768
-                    type: string
-                  observedGeneration:
-                    description: observedGeneration represents the .metadata.generation
-                      that the condition was set based upon. For instance, if .metadata.generation
-                      is currently 12, but the .status.conditions[x].observedGeneration
-                      is 9, the condition is out of date with respect to the current
-                      state of the instance.
-                    format: int64
-                    minimum: 0
-                    type: integer
-                  reason:
-                    description: reason contains a programmatic identifier indicating
-                      the reason for the condition's last transition. Producers of
-                      specific condition types may define expected values and meanings
-                      for this field, and whether the values are considered a guaranteed
-                      API. The value should be a CamelCase string. This field may
-                      not be empty.
-                    maxLength: 1024
-                    minLength: 1
-                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    type: string
-                  status:
-                    description: status of the condition, one of True, False, Unknown.
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                  type:
-                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      --- Many .condition.type values are consistent across resources
-                      like Available, but because arbitrary conditions can be useful
-                      (see .node.status.conditions), the ability to deconflict is
-                      important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                    maxLength: 316
-                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                    type: string
-                required:
-                - lastTransitionTime
-                - message
-                - reason
-                - status
-                - type
-                type: object
-              type: array
-          type: object
-      required:
-      - spec
-      type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-
----
-apiVersion: apis.kcp.dev/v1alpha1
-kind: APIResourceSchema
-metadata:
-  creationTimestamp: null
-  name: v202211031948.applicationsnapshots.appstudio.redhat.com
-spec:
-  group: appstudio.redhat.com
-  names:
-    kind: ApplicationSnapshot
-    listKind: ApplicationSnapshotList
-    plural: applicationsnapshots
-    shortNames:
-    - as
-    - snapshot
-    singular: applicationsnapshot
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      description: ApplicationSnapshot is the Schema for the applicationsnapshots
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ApplicationSnapshotSpec defines the desired state of ApplicationSnapshot
-          properties:
-            application:
-              description: Application is a reference to the name of an Application
-                resource within the same namespace, which defines the target application
-                for the Snapshot (when used with a Binding).
-              type: string
-            artifacts:
-              description: Artifacts is a placeholder section for 'artifact links'
-                we want to maintain to other AppStudio resources. See Environment
-                API doc for details.
-              properties:
-                unstableFields:
-                  description: 'NOTE: This field (and struct) are placeholders. -
-                    Until this API is stabilized, consumers of the API may store any
-                    unstructured JSON/YAML data here,   but no backwards compatibility
-                    will be preserved.'
-                  x-kubernetes-preserve-unknown-fields: true
-              type: object
-            components:
-              description: Components field contains the sets of components to deploy
-                as part of this snapshot.
-              items:
-                description: ApplicationSnapshotComponent
-                properties:
-                  containerImage:
-                    description: ContainerImage is the container image to use when
-                      deploying the component, as part of a Snapshot
-                    type: string
-                  name:
-                    description: Name is the name of the component
-                    type: string
-                required:
-                - containerImage
-                - name
-                type: object
-              type: array
-            displayDescription:
-              description: DisplayDescription is a user-visible, user definable description
-                for the resource (and is not used for any functional behaviour)
-              type: string
-            displayName:
-              description: DisplayName is a user-visible, user-definable name for
-                the resource (and is not used for any functional behaviour)
-              type: string
-          required:
-          - application
-          type: object
-        status:
-          description: ApplicationSnapshotStatus defines the observed state of ApplicationSnapshot
-          properties:
-            conditions:
-              description: Conditions represent the latest available observations
-                for the Snapshot
-              items:
-                description: "Condition contains details for one aspect of the current
-                  state of this API Resource. --- This struct is intended for direct
-                  use as an array at the field path .status.conditions.  For example,
-                  type FooStatus struct{     // Represents the observations of a foo's
-                  current state.     // Known .status.conditions.type are: \"Available\",
-                  \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     //
-                  +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                  \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                  patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                  \n     // other fields }"
-                properties:
-                  lastTransitionTime:
-                    description: lastTransitionTime is the last time the condition
-                      transitioned from one status to another. This should be when
-                      the underlying condition changed.  If that is not known, then
-                      using the time when the API field changed is acceptable.
-                    format: date-time
-                    type: string
-                  message:
-                    description: message is a human readable message indicating details
-                      about the transition. This may be an empty string.
-                    maxLength: 32768
-                    type: string
-                  observedGeneration:
-                    description: observedGeneration represents the .metadata.generation
-                      that the condition was set based upon. For instance, if .metadata.generation
-                      is currently 12, but the .status.conditions[x].observedGeneration
-                      is 9, the condition is out of date with respect to the current
-                      state of the instance.
-                    format: int64
-                    minimum: 0
-                    type: integer
-                  reason:
-                    description: reason contains a programmatic identifier indicating
-                      the reason for the condition's last transition. Producers of
-                      specific condition types may define expected values and meanings
-                      for this field, and whether the values are considered a guaranteed
-                      API. The value should be a CamelCase string. This field may
-                      not be empty.
-                    maxLength: 1024
-                    minLength: 1
-                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    type: string
-                  status:
-                    description: status of the condition, one of True, False, Unknown.
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                  type:
-                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      --- Many .condition.type values are consistent across resources
-                      like Available, but because arbitrary conditions can be useful
-                      (see .node.status.conditions), the ability to deconflict is
-                      important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                    maxLength: 316
-                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                    type: string
-                required:
-                - lastTransitionTime
-                - message
-                - reason
-                - status
-                - type
-                type: object
-              type: array
-          type: object
-      type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-
----
-apiVersion: apis.kcp.dev/v1alpha1
-kind: APIResourceSchema
-metadata:
-  creationTimestamp: null
-  name: v202211021841.componentdetectionqueries.appstudio.redhat.com
+  name: v202211101622.componentdetectionqueries.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -1051,7 +593,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202211092111.components.appstudio.redhat.com
+  name: v202211101622.components.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -1415,7 +957,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202211092111.environments.appstudio.redhat.com
+  name: v202211101622.environments.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -1546,8 +1088,11 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202211092111.promotionruns.appstudio.redhat.com
+  name: v202211101622.promotionruns.appstudio.redhat.com
 spec:
+  group: appstudio.redhat.com
+  names:
+    kind: PromotionRun
     listKind: PromotionRunList
     plural: promotionruns
     shortNames:
@@ -1715,7 +1260,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202211092111.snapshotenvironmentbindings.appstudio.redhat.com
+  name: v202211101622.snapshotenvironmentbindings.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -2076,8 +1621,11 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202211092111.snapshots.appstudio.redhat.com
+  name: v202211101622.snapshots.appstudio.redhat.com
 spec:
+  group: appstudio.redhat.com
+  names:
+    kind: Snapshot
     listKind: SnapshotList
     plural: snapshots
     shortNames:

--- a/config/kcp/apiresourceschema.yaml
+++ b/config/kcp/apiresourceschema.yaml
@@ -23,10 +23,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .status.conditions[0].status
+    - jsonPath: .status.conditions[-1].status
       name: Status
       type: string
-    - jsonPath: .status.conditions[0].reason
+    - jsonPath: .status.conditions[-1].reason
       name: Reason
       type: string
     name: v1alpha1
@@ -191,7 +191,468 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
+<<<<<<< HEAD
   name: v202211092111.componentdetectionqueries.appstudio.redhat.com
+=======
+  name: v202211021841.applicationsnapshotenvironmentbindings.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: ApplicationSnapshotEnvironmentBinding
+    listKind: ApplicationSnapshotEnvironmentBindingList
+    plural: applicationsnapshotenvironmentbindings
+    shortNames:
+    - aseb
+    - binding
+    singular: applicationsnapshotenvironmentbinding
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      description: ApplicationSnapshotEnvironmentBinding is the Schema for the applicationsnapshotenvironmentbindings
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ApplicationSnapshotEnvironmentBindingSpec defines the desired
+            state of ApplicationSnapshotEnvironmentBinding
+          properties:
+            application:
+              description: Application is a reference to the Application resource
+                (defined in the namespace) involved in the binding
+              type: string
+            components:
+              description: Components contains individual component data
+              items:
+                description: BindingComponent contains individual component data
+                properties:
+                  configuration:
+                    description: Configuration describes GitOps repository customizations
+                      that are specific to the the component-application-environment
+                      combination. - Values defined in this struct will overwrite
+                      values from Application/Environment/Component
+                    properties:
+                      env:
+                        description: Env describes environment variables to use for
+                          the component
+                        items:
+                          description: EnvVarPair describes environment variables
+                            to use for the component
+                          properties:
+                            name:
+                              description: Name is the environment variable name
+                              type: string
+                            value:
+                              description: Value is the environment variable value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      replicas:
+                        description: Replicas defines the number of replicas to use
+                          for the component
+                        type: integer
+                      resources:
+                        description: Resources defines the Compute Resources required
+                          by the component
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                    required:
+                    - replicas
+                    type: object
+                  name:
+                    description: Name is the name of the component.
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            environment:
+              description: Environment is the Environment resource (defined in the
+                namespace) that the binding will deploy to
+              type: string
+            snapshot:
+              description: Snapshot is the Snapshot resource (defined in the namespace)
+                that contains the container image versions for the components of the
+                Application
+              type: string
+          required:
+          - application
+          - components
+          - environment
+          - snapshot
+          type: object
+        status:
+          description: ApplicationSnapshotEnvironmentBindingStatus defines the observed
+            state of ApplicationSnapshotEnvironmentBinding
+          properties:
+            components:
+              description: Components describes a component's GitOps repository information.
+                This status is updated by the Application Service controller.
+              items:
+                description: ComponentStatus contains the status of the components
+                properties:
+                  gitopsRepository:
+                    description: GitOpsRepository contains the Git URL, path, branch,
+                      and most recent commit id for the component
+                    properties:
+                      branch:
+                        description: Branch is the branch to use when accessing the
+                          GitOps repository
+                        type: string
+                      commitID:
+                        description: CommitID contains the most recent commit ID for
+                          which the Kubernetes resources of the Component were modified.
+                        type: string
+                      generatedResources:
+                        description: GeneratedResources contains the list of GitOps
+                          repository resources generated by the application service
+                          controller in the overlays/<environment> dir, for example,
+                          'deployment-patch.yaml'. This is stored to differentiate
+                          between application-service controller generated resources
+                          vs resources added by a user
+                        items:
+                          type: string
+                        type: array
+                      path:
+                        description: 'Path is a pointer to a folder in the GitOps
+                          repo, containing a kustomization.yaml NOTE: Each component-env
+                          combination must have it''s own separate path'
+                        type: string
+                      url:
+                        description: URL is the Git repository URL e.g. The Git repository
+                          that contains the K8s resources to deployment for the component
+                          of the application.
+                        type: string
+                    required:
+                    - branch
+                    - commitID
+                    - generatedResources
+                    - path
+                    - url
+                    type: object
+                  name:
+                    description: Name is the name of the component.
+                    type: string
+                required:
+                - gitopsRepository
+                - name
+                type: object
+              type: array
+            gitopsDeployments:
+              description: GitOpsDeployments describes the set of GitOpsDeployment
+                resources that correspond to the binding. To determine the health/sync
+                status of a binding, you can look at the GitOpsDeployments decribed
+                here.
+              items:
+                description: "BindingStatusGitOpsDeployment describes an individual
+                  reference to a GitOpsDeployment resources that is used to deploy
+                  this binding. \n To determine the health/sync status of a binding,
+                  you can look at the GitOpsDeployments decribed here."
+                properties:
+                  componentName:
+                    description: ComponentName is the name of the component in the
+                      (component, gitopsdeployment) pair
+                    type: string
+                  gitopsDeployment:
+                    description: GitOpsDeployment is a reference to the name of a
+                      GitOpsDeployment resource which is used to deploy the binding.
+                      The Health/sync status for the binding can thus be read from
+                      the references GitOpsDEployment
+                    type: string
+                required:
+                - componentName
+                type: object
+              type: array
+            gitopsRepoConditions:
+              description: Condition describes operations on the GitOps repository,
+                for example, if there were issues with generating/processing the repository.
+                This status is updated by the Application Service controller.
+              items:
+                description: "Condition contains details for one aspect of the current
+                  state of this API Resource. --- This struct is intended for direct
+                  use as an array at the field path .status.conditions.  For example,
+                  type FooStatus struct{     // Represents the observations of a foo's
+                  current state.     // Known .status.conditions.type are: \"Available\",
+                  \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     //
+                  +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                  \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                  patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                  \n     // other fields }"
+                properties:
+                  lastTransitionTime:
+                    description: lastTransitionTime is the last time the condition
+                      transitioned from one status to another. This should be when
+                      the underlying condition changed.  If that is not known, then
+                      using the time when the API field changed is acceptable.
+                    format: date-time
+                    type: string
+                  message:
+                    description: message is a human readable message indicating details
+                      about the transition. This may be an empty string.
+                    maxLength: 32768
+                    type: string
+                  observedGeneration:
+                    description: observedGeneration represents the .metadata.generation
+                      that the condition was set based upon. For instance, if .metadata.generation
+                      is currently 12, but the .status.conditions[x].observedGeneration
+                      is 9, the condition is out of date with respect to the current
+                      state of the instance.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  reason:
+                    description: reason contains a programmatic identifier indicating
+                      the reason for the condition's last transition. Producers of
+                      specific condition types may define expected values and meanings
+                      for this field, and whether the values are considered a guaranteed
+                      API. The value should be a CamelCase string. This field may
+                      not be empty.
+                    maxLength: 1024
+                    minLength: 1
+                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    type: string
+                  status:
+                    description: status of the condition, one of True, False, Unknown.
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      --- Many .condition.type values are consistent across resources
+                      like Available, but because arbitrary conditions can be useful
+                      (see .node.status.conditions), the ability to deconflict is
+                      important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                    maxLength: 316
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    type: string
+                required:
+                - lastTransitionTime
+                - message
+                - reason
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v202211021841.applicationsnapshots.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: ApplicationSnapshot
+    listKind: ApplicationSnapshotList
+    plural: applicationsnapshots
+    shortNames:
+    - as
+    - snapshot
+    singular: applicationsnapshot
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      description: ApplicationSnapshot is the Schema for the applicationsnapshots
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ApplicationSnapshotSpec defines the desired state of ApplicationSnapshot
+          properties:
+            application:
+              description: Application is a reference to the name of an Application
+                resource within the same namespace, which defines the target application
+                for the Snapshot (when used with a Binding).
+              type: string
+            artifacts:
+              description: Artifacts is a placeholder section for 'artifact links'
+                we want to maintain to other AppStudio resources. See Environment
+                API doc for details.
+              properties:
+                unstableFields:
+                  description: 'NOTE: This field (and struct) are placeholders. -
+                    Until this API is stabilized, consumers of the API may store any
+                    unstructured JSON/YAML data here,   but no backwards compatibility
+                    will be preserved.'
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+            components:
+              description: Components field contains the sets of components to deploy
+                as part of this snapshot.
+              items:
+                description: ApplicationSnapshotComponent
+                properties:
+                  containerImage:
+                    description: ContainerImage is the container image to use when
+                      deploying the component, as part of a Snapshot
+                    type: string
+                  name:
+                    description: Name is the name of the component
+                    type: string
+                required:
+                - containerImage
+                - name
+                type: object
+              type: array
+            displayDescription:
+              description: DisplayDescription is a user-visible, user definable description
+                for the resource (and is not used for any functional behaviour)
+              type: string
+            displayName:
+              description: DisplayName is a user-visible, user-definable name for
+                the resource (and is not used for any functional behaviour)
+              type: string
+          required:
+          - application
+          type: object
+        status:
+          description: ApplicationSnapshotStatus defines the observed state of ApplicationSnapshot
+          properties:
+            conditions:
+              description: Conditions represent the latest available observations
+                for the Snapshot
+              items:
+                description: "Condition contains details for one aspect of the current
+                  state of this API Resource. --- This struct is intended for direct
+                  use as an array at the field path .status.conditions.  For example,
+                  type FooStatus struct{     // Represents the observations of a foo's
+                  current state.     // Known .status.conditions.type are: \"Available\",
+                  \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     //
+                  +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                  \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                  patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                  \n     // other fields }"
+                properties:
+                  lastTransitionTime:
+                    description: lastTransitionTime is the last time the condition
+                      transitioned from one status to another. This should be when
+                      the underlying condition changed.  If that is not known, then
+                      using the time when the API field changed is acceptable.
+                    format: date-time
+                    type: string
+                  message:
+                    description: message is a human readable message indicating details
+                      about the transition. This may be an empty string.
+                    maxLength: 32768
+                    type: string
+                  observedGeneration:
+                    description: observedGeneration represents the .metadata.generation
+                      that the condition was set based upon. For instance, if .metadata.generation
+                      is currently 12, but the .status.conditions[x].observedGeneration
+                      is 9, the condition is out of date with respect to the current
+                      state of the instance.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  reason:
+                    description: reason contains a programmatic identifier indicating
+                      the reason for the condition's last transition. Producers of
+                      specific condition types may define expected values and meanings
+                      for this field, and whether the values are considered a guaranteed
+                      API. The value should be a CamelCase string. This field may
+                      not be empty.
+                    maxLength: 1024
+                    minLength: 1
+                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    type: string
+                  status:
+                    description: status of the condition, one of True, False, Unknown.
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      --- Many .condition.type values are consistent across resources
+                      like Available, but because arbitrary conditions can be useful
+                      (see .node.status.conditions), the ability to deconflict is
+                      important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                    maxLength: 316
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    type: string
+                required:
+                - lastTransitionTime
+                - message
+                - reason
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v202211021841.componentdetectionqueries.appstudio.redhat.com
+>>>>>>> 8f9ce71 (add type to cdq)
 spec:
   group: appstudio.redhat.com
   names:
@@ -213,6 +674,9 @@ spec:
       type: string
     - jsonPath: .status.conditions[-1].reason
       name: Reason
+      type: string
+    - jsonPath: .status.conditions[-1].type
+      name: Type
       type: string
     name: v1alpha1
     schema:
@@ -590,7 +1054,11 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
+<<<<<<< HEAD
   name: v202211092111.components.appstudio.redhat.com
+=======
+  name: v202211021841.components.appstudio.redhat.com
+>>>>>>> 8f9ce71 (add type to cdq)
 spec:
   group: appstudio.redhat.com
   names:
@@ -608,10 +1076,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .status.conditions[0].status
+    - jsonPath: .status.conditions[-1].status
       name: Status
       type: string
-    - jsonPath: .status.conditions[0].reason
+    - jsonPath: .status.conditions[-1].reason
       name: Reason
       type: string
     name: v1alpha1
@@ -951,7 +1419,11 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
+<<<<<<< HEAD
   name: v202211092111.environments.appstudio.redhat.com
+=======
+  name: v202211021841.environments.appstudio.redhat.com
+>>>>>>> 8f9ce71 (add type to cdq)
 spec:
   group: appstudio.redhat.com
   names:

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -932,6 +932,19 @@ spec:
         required:
         - spec
         type: object
+    additionalPrinterColumns:
+      - name: Age
+        jsonPath: .metadata.creationTimestamp
+        description: The age of this resource
+        type: date
+      - name: Type
+        type: string
+        description: The type of component condition
+        jsonPath: .status.conditions[0].type
+      - name: Status
+        type: string
+        description: The status of component
+        jsonPath: .status.conditions[0].status
     served: true
     storage: true
     subresources:

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -22,10 +22,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .status.conditions[0].status
+    - jsonPath: .status.conditions[-1].status
       name: Status
       type: string
-    - jsonPath: .status.conditions[0].reason
+    - jsonPath: .status.conditions[-1].reason
       name: Reason
       type: string
     name: v1alpha1
@@ -221,6 +221,9 @@ spec:
       type: string
     - jsonPath: .status.conditions[-1].reason
       name: Reason
+      type: string
+    - jsonPath: .status.conditions[-1].type
+      name: Type
       type: string
     name: v1alpha1
     schema:
@@ -627,10 +630,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .status.conditions[0].status
+    - jsonPath: .status.conditions[-1].status
       name: Status
       type: string
-    - jsonPath: .status.conditions[0].reason
+    - jsonPath: .status.conditions[-1].reason
       name: Reason
       type: string
     name: v1alpha1

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -18,7 +18,17 @@ spec:
     singular: application
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[0].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Application is the Schema for the applications API
@@ -202,7 +212,17 @@ spec:
     singular: componentdetectionquery
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[-1].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[-1].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ComponentDetectionQuery is the Schema for the componentdetectionqueries
@@ -603,7 +623,17 @@ spec:
     singular: component
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[0].reason
+      name: Reason
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Component is the Schema for the components API
@@ -932,19 +962,6 @@ spec:
         required:
         - spec
         type: object
-    additionalPrinterColumns:
-      - name: Age
-        jsonPath: .metadata.creationTimestamp
-        description: The age of this resource
-        type: date
-      - name: Type
-        type: string
-        description: The type of component condition
-        jsonPath: .status.conditions[0].type
-      - name: Status
-        type: string
-        description: The status of component
-        jsonPath: .status.conditions[0].status
     served: true
     storage: true
     subresources:

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -636,6 +636,9 @@ spec:
     - jsonPath: .status.conditions[-1].reason
       name: Reason
       type: string
+    - jsonPath: .status.conditions[-1].type
+      name: Type
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
For issue: https://issues.redhat.com/browse/DEVHAS-49

This PR adds additional printer columns to component/application/cdq 's GET output
added latest condition fields - `status`, `reason`, and `type` (specifically for cdq, since cdq has in-progress and complete status) to the CRDs

for component & application:
```
$ kubectl get hc
NAME                      AGE    STATUS   REASON
devfile-sample-go-basic   111s   True     OK
$ kubectl get ha
NAME                 AGE   STATUS   REASON
application-sample   17s   True     OK
```

failure case: 
```
$ kubectl get hc
NAME                      AGE   STATUS   REASON
devfile-sample-go-basic   8s    False    Error
```

For CDQ, in-progress & complete:
```
$ kubectl get hcdq
NAME                              AGE     STATUS   REASON    TYPE
componentdetectionquery-sample    14s     True     Success   Processing
componentdetectionquery-sample1   2m52s   True     OK        Completed
```