### PR TITLE
[DEVHAS-206] Add webhook for validating spec.displayName

### DIFF
--- a/api/v1alpha1/application_webhook.go
+++ b/api/v1alpha1/application_webhook.go
@@ -56,7 +56,7 @@ var _ webhook.Validator = &Application{}
 func (r *Application) ValidateCreate() error {
 
 	if r.Spec.DisplayName == "" {
-		return fmt.Errorf("Display Name must be provided when creating an Application")
+		return fmt.Errorf("display name must be provided when creating an Application")
 	}
 	return nil
 }

--- a/api/v1alpha1/application_webhook.go
+++ b/api/v1alpha1/application_webhook.go
@@ -55,7 +55,9 @@ var _ webhook.Validator = &Application{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Application) ValidateCreate() error {
 
-	// TODO(user): fill in your validation logic upon object creation.
+	if r.Spec.DisplayName == "" {
+		return fmt.Errorf("spec.displayName must be provided when creating an Application")
+	}
 	return nil
 }
 

--- a/api/v1alpha1/application_webhook.go
+++ b/api/v1alpha1/application_webhook.go
@@ -56,7 +56,7 @@ var _ webhook.Validator = &Application{}
 func (r *Application) ValidateCreate() error {
 
 	if r.Spec.DisplayName == "" {
-		return fmt.Errorf("spec.displayName must be provided when creating an Application")
+		return fmt.Errorf("Display Name must be provided when creating an Application")
 	}
 	return nil
 }

--- a/api/v1alpha1/application_webhook_test.go
+++ b/api/v1alpha1/application_webhook_test.go
@@ -44,6 +44,33 @@ var _ = Describe("Application validation webhook", func() {
 		Description     = "Simple petclinic app"
 	)
 
+	Context("Create Application CR with missing displayName", func() {
+		It("Should fail with error saying displayName is required field", func() {
+			ctx := context.Background()
+
+			hasApp := &Application{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Application",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      HASAppName,
+					Namespace: HASAppNamespace,
+				},
+				Spec: ApplicationSpec{
+					AppModelRepository: ApplicationGitRepository{
+						URL: "https://github.com/testorg/petclinic-app",
+					},
+					GitOpsRepository: ApplicationGitRepository{
+						URL: "https://github.com/testorg/gitops-app",
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, hasApp)).Should(Not(Succeed()))
+		})
+	})
+
 	Context("Update Application CR fields", func() {
 		It("Should update non immutable fields successfully and err out on immutable fields", func() {
 			ctx := context.Background()


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-206

Updates the application webhook to validate on create that `spec.displayName` is set to a non-empty string.