### PR TITLE
Add initial support for Snapshot validating webhook

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -44,7 +44,7 @@ resources:
     namespaced: true
   domain: redhat.com
   group: appstudio
-  kind: ApplicationSnapshotEnvironmentBinding
+  kind: SnapshotEnvironmentBinding
   path: github.com/redhat-appstudio/application-api/api/v1alpha1
   version: v1alpha1
 - api:
@@ -52,15 +52,18 @@ resources:
     namespaced: true
   domain: redhat.com
   group: appstudio
-  kind: ApplicationSnapshot
+  kind: Snapshot
   path: github.com/redhat-appstudio/application-api/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true
   domain: redhat.com
   group: appstudio
-  kind: ApplicationPromotionRun
+  kind: PromotionRun
   path: github.com/redhat-appstudio/application-api/api/v1alpha1
   version: v1alpha1
 - api:

--- a/api/v1alpha1/snapshot_webhook.go
+++ b/api/v1alpha1/snapshot_webhook.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var snapshotlog = logf.Log.WithName("snapshot-resource")
+
+func (r *Snapshot) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-snapshot,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=snapshots,verbs=create;update,versions=v1alpha1,name=vsnapshot.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &Snapshot{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *Snapshot) ValidateCreate() error {
+	snapshotlog.Info("validate create", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object creation.
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *Snapshot) ValidateUpdate(old runtime.Object) error {
+	snapshotlog.Info("validate update", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object update.
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *Snapshot) ValidateDelete() error {
+	snapshotlog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
+}

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -104,6 +104,9 @@ var _ = BeforeSuite(func() {
 	err = (&Application{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&Snapshot{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -98,3 +98,23 @@ webhooks:
     resources:
     - components
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-snapshot
+  failurePolicy: Fail
+  name: vsnapshot.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - snapshots
+  sideEffects: None


### PR DESCRIPTION
**This PR**:
- Adds a new `Snapshot` resource webhook scaffolding via `operator-sdk create webhook`
    - The webhook API URL will be handled by the appstudio-controller of GitOps Service. See https://github.com/redhat-appstudio/managed-gitops/pull/289 for this work.
- Fixes old references in the PROJECT file, and adds webhooks
- Regenerates the manifests using `make generate manifests`

A part of JIRA story https://issues.redhat.com/browse/GITOPSRVCE-211