### PR TITLE
Add constants for SnapshotEnvironmentBindingStatus' ComponentDeploymentCondition's field

### DIFF
--- a/api/v1alpha1/snapshotenvironmentbinding_types.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_types.go
@@ -21,6 +21,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Constants used with SnapshotEnvironmentBindingStatus's ComponentDeploymentConditions field
+const (
+	ComponentDeploymentConditionAllComponentsDeployed = "AllComponentsDeployed"
+	ComponentDeploymentConditionCommitsSynced         = "CommitsSynced"
+	ComponentDeploymentConditionCommitsUnsynced       = "CommitsUnsynced"
+	ComponentDeploymentConditionErrorOccurred         = "ErrorOccurred"
+)
+
 // SnapshotEnvironmentBindingSpec defines the desired state of SnapshotEnvironmentBinding
 type SnapshotEnvironmentBindingSpec struct {
 


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

This PR adds the constants used by SnapshotEnvironmentBindingStatus' ComponentDeploymentCondition's field, so that other teams can use them.

This is part of Jira story https://issues.redhat.com/browse/GITOPSRVCE-346