### PR TITLE
Add Webhooks for CRs to avoid modifications in immutable fields.

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -47,6 +47,10 @@ resources:
   kind: SnapshotEnvironmentBinding
   path: github.com/redhat-appstudio/application-api/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true
@@ -66,6 +70,10 @@ resources:
   kind: PromotionRun
   path: github.com/redhat-appstudio/application-api/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/api/v1alpha1/promotionrun_webhook unit_test.go
+++ b/api/v1alpha1/promotionrun_webhook unit_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2021-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPromotionRunValidatingWebhook(t *testing.T) {
+
+	originalPromotionRun := PromotionRun{
+		Spec: PromotionRunSpec{
+			Snapshot:    "test-snapshot-a",
+			Application: "test-app-a",
+			ManualPromotion: ManualPromotionConfiguration{
+				TargetEnvironment: "test-env-a",
+			},
+		},
+	}
+
+	tests := []struct {
+		testName      string       // Name of test
+		testData      PromotionRun // Test data to be passed to webhook function
+		expectedError string       // Expected error message from webhook function
+	}{
+		{
+			testName: "No error when Spec is same.",
+			testData: PromotionRun{
+				Spec: PromotionRunSpec{
+					Snapshot:    "test-snapshot-a",
+					Application: "test-app-a",
+					ManualPromotion: ManualPromotionConfiguration{
+						TargetEnvironment: "test-env-a",
+					},
+				},
+			},
+			expectedError: "",
+		},
+
+		{
+			testName: "Error occurs when Spec.Snapshot is changed.",
+			testData: PromotionRun{
+				Spec: PromotionRunSpec{
+					Snapshot:    "test-snapshot-a-changed",
+					Application: "test-app-a",
+					ManualPromotion: ManualPromotionConfiguration{
+						TargetEnvironment: "test-env-a",
+					},
+				},
+			},
+			expectedError: "spec cannot be updated to {Snapshot:test-snapshot-a-changed Application:test-app-a ManualPromotion:{TargetEnvironment:test-env-a} AutomatedPromotion:{InitialEnvironment:}}",
+		},
+
+		{
+			testName: "Error occurs when Spec.Application is changed.",
+			testData: PromotionRun{
+				Spec: PromotionRunSpec{
+					Snapshot:    "test-snapshot-a",
+					Application: "test-app-a-changed",
+					ManualPromotion: ManualPromotionConfiguration{
+						TargetEnvironment: "test-env-a",
+					},
+				},
+			},
+			expectedError: "spec cannot be updated to {Snapshot:test-snapshot-a Application:test-app-a-changed ManualPromotion:{TargetEnvironment:test-env-a} AutomatedPromotion:{InitialEnvironment:}}",
+		},
+
+		{
+			testName: "Error occurs when Spec.Application is changed.",
+			testData: PromotionRun{
+				Spec: PromotionRunSpec{
+					Snapshot:    "test-snapshot-a",
+					Application: "test-app-a-changed",
+					ManualPromotion: ManualPromotionConfiguration{
+						TargetEnvironment: "test-env-a-changed",
+					},
+				},
+			},
+			expectedError: "spec cannot be updated to {Snapshot:test-snapshot-a Application:test-app-a-changed ManualPromotion:{TargetEnvironment:test-env-a-changed} AutomatedPromotion:{InitialEnvironment:}}",
+		},
+
+		{
+			testName: "Error occurs when Spec.AutomatedPromotion is added.",
+			testData: PromotionRun{
+				Spec: PromotionRunSpec{
+					Snapshot:    "test-snapshot-a",
+					Application: "test-app-a-changed",
+					AutomatedPromotion: AutomatedPromotionConfiguration{
+						InitialEnvironment: "test-env-a",
+					},
+				},
+			},
+			expectedError: "spec cannot be updated to {Snapshot:test-snapshot-a Application:test-app-a-changed ManualPromotion:{TargetEnvironment:} AutomatedPromotion:{InitialEnvironment:test-env-a}}",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			actualError := test.testData.ValidateUpdate(&originalPromotionRun)
+
+			if test.expectedError == "" {
+				assert.Nil(t, actualError)
+			} else {
+				assert.Contains(t, actualError.Error(), test.expectedError)
+			}
+		})
+	}
+}

--- a/api/v1alpha1/promotionrun_webhook.go
+++ b/api/v1alpha1/promotionrun_webhook.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var promotionrunlog = logf.Log.WithName("promotionrun-resource")
+
+func (r *PromotionRun) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-appstudio-redhat-com-v1alpha1-promotionrun,mutating=true,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=promotionruns,verbs=create;update,versions=v1alpha1,name=mpromotionrun.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &PromotionRun{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *PromotionRun) Default() {
+	promotionrunlog.Info("default", "name", r.Name)
+}
+
+// change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-promotionrun,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=promotionruns,verbs=create;update,versions=v1alpha1,name=vpromotionrun.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &PromotionRun{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *PromotionRun) ValidateCreate() error {
+	promotionrunlog.Info("validate create", "name", r.Name)
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *PromotionRun) ValidateUpdate(old runtime.Object) error {
+	promotionrunlog.Info("validate update", "name", r.Name)
+
+	switch old := old.(type) {
+	case *PromotionRun:
+
+		if !reflect.DeepEqual(r.Spec, old.Spec) {
+			return fmt.Errorf("spec cannot be updated to %+v", r.Spec)
+		}
+
+	default:
+		return fmt.Errorf("runtime object is not of type PromotionRun")
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *PromotionRun) ValidateDelete() error {
+	promotionrunlog.Info("validate delete", "name", r.Name)
+
+	return nil
+}

--- a/api/v1alpha1/snapshot_webhook unit_test.go
+++ b/api/v1alpha1/snapshot_webhook unit_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2021-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSnapshotValidatingWebhook(t *testing.T) {
+
+	// Create initial Snapshot CR.
+	originalSnapshot := Snapshot{
+		Spec: SnapshotSpec{
+			Application: "test-app-a",
+			Components: []SnapshotComponent{
+				{
+					Name:           "test-component-a",
+					ContainerImage: "test-container-image-a",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		testName      string   // Name of test
+		testData      Snapshot // Test data to be passed to webhook function
+		expectedError string   // Expected error message from webhook function
+	}{
+		{
+			testName: "No error when Spec is same.",
+			testData: Snapshot{
+				Spec: SnapshotSpec{
+					Application: "test-app-a",
+					Components: []SnapshotComponent{
+						{
+							Name:           "test-component-a",
+							ContainerImage: "test-container-image-a",
+						},
+					},
+				},
+			},
+			expectedError: "",
+		},
+
+		{
+			testName: "Error occurs when Spec.Application name is changed.",
+			testData: Snapshot{
+				Spec: SnapshotSpec{
+					Application: "test-app-a-changed",
+					Components: []SnapshotComponent{
+						{
+							Name:           "test-component-a",
+							ContainerImage: "test-container-image-a",
+						},
+					},
+				},
+			},
+			expectedError: "application cannot be updated to test-app-a-changed",
+		},
+
+		{
+			testName: "Error occurs when Spec.Components.Name is changed.",
+			testData: Snapshot{
+				Spec: SnapshotSpec{
+					Application: "test-app-a",
+					Components: []SnapshotComponent{
+						{
+							Name:           "test-component-a-changed",
+							ContainerImage: "test-container-image-a",
+						},
+					},
+				},
+			},
+			expectedError: "components cannot be updated to [{Name:test-component-a-changed ContainerImage:test-container-image-a}]",
+		},
+
+		{
+			testName: "Error occurs when Spec.Components.ContainerImage is changed.",
+			testData: Snapshot{
+				Spec: SnapshotSpec{
+					Application: "test-app-a",
+					Components: []SnapshotComponent{
+						{
+							Name:           "test-component-a",
+							ContainerImage: "test-container-image-a-changed",
+						},
+					},
+				},
+			},
+			expectedError: "components cannot be updated to [{Name:test-component-a ContainerImage:test-container-image-a-changed}]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			actualError := test.testData.ValidateUpdate(&originalSnapshot)
+
+			if test.expectedError == "" {
+				assert.Nil(t, actualError)
+			} else {
+				assert.Contains(t, actualError.Error(), test.expectedError)
+			}
+		})
+	}
+}

--- a/api/v1alpha1/snapshot_webhook.go
+++ b/api/v1alpha1/snapshot_webhook.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+	"reflect"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -32,7 +35,7 @@ func (r *Snapshot) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+// change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-snapshot,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=snapshots,verbs=create;update,versions=v1alpha1,name=vsnapshot.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &Snapshot{}
@@ -41,7 +44,6 @@ var _ webhook.Validator = &Snapshot{}
 func (r *Snapshot) ValidateCreate() error {
 	snapshotlog.Info("validate create", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object creation.
 	return nil
 }
 
@@ -49,7 +51,21 @@ func (r *Snapshot) ValidateCreate() error {
 func (r *Snapshot) ValidateUpdate(old runtime.Object) error {
 	snapshotlog.Info("validate update", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object update.
+	switch old := old.(type) {
+	case *Snapshot:
+
+		if !reflect.DeepEqual(r.Spec.Application, old.Spec.Application) {
+			return fmt.Errorf("application cannot be updated to %+v", r.Spec.Application)
+		}
+
+		if !reflect.DeepEqual(r.Spec.Components, old.Spec.Components) {
+			return fmt.Errorf("components cannot be updated to %+v", r.Spec.Components)
+		}
+
+	default:
+		return fmt.Errorf("runtime object is not of type Snapshot")
+	}
+
 	return nil
 }
 
@@ -57,6 +73,5 @@ func (r *Snapshot) ValidateUpdate(old runtime.Object) error {
 func (r *Snapshot) ValidateDelete() error {
 	snapshotlog.Info("validate delete", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object deletion.
 	return nil
 }

--- a/api/v1alpha1/snapshotenvironmentbinding_webhook unit_test.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_webhook unit_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2021-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSnapshotEnvironmentBindingValidatingWebhook(t *testing.T) {
+
+	originalBinding := SnapshotEnvironmentBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Labels: map[string]string{"test-key-a": "test-value-a"},
+		},
+		Spec: SnapshotEnvironmentBindingSpec{
+			Application: "test-app-a",
+			Environment: "test-env-a",
+		},
+	}
+
+	tests := []struct {
+		testName      string                     // Name of test
+		testData      SnapshotEnvironmentBinding // Test data to be passed to webhook function
+		expectedError string                     // Expected error message from webhook function
+	}{
+		{
+			testName: "No error when Spec is same.",
+			testData: SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"test-key-a": "test-value-a"},
+				},
+				Spec: SnapshotEnvironmentBindingSpec{
+					Application: "test-app-a",
+					Environment: "test-env-a",
+				},
+			},
+			expectedError: "",
+		},
+
+		{
+			testName: "Error occurs when Spec.Application name is changed.",
+			testData: SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"test-key-a": "test-value-a"},
+				},
+				Spec: SnapshotEnvironmentBindingSpec{
+					Application: "test-app-a-changed",
+					Environment: "test-env-a",
+				},
+			},
+			expectedError: "application cannot be updated to test-app-a-changed",
+		},
+
+		{
+			testName: "Error occurs when Spec.Environment name is changed.",
+			testData: SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"test-key-a": "test-value-a"},
+				},
+				Spec: SnapshotEnvironmentBindingSpec{
+					Application: "test-app-a",
+					Environment: "test-env-a-changed",
+				},
+			},
+			expectedError: "environment cannot be updated to test-env-a-changed",
+		},
+
+		{
+			testName: "Error occurs when existing label is changed.",
+			testData: SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"test-key-a": "test-value-b"},
+				},
+				Spec: SnapshotEnvironmentBindingSpec{
+					Application: "test-app-a",
+					Environment: "test-env-a-changed",
+				},
+			},
+			expectedError: "labels cannot be updated to map[test-key-a:test-value-b]",
+		},
+
+		{
+			testName: "Error occurs when new label is added.",
+			testData: SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						"test-key-a": "test-value-a",
+						"test-key-b": "test-value-b",
+					},
+				},
+				Spec: SnapshotEnvironmentBindingSpec{
+					Application: "test-app-a",
+					Environment: "test-env-a-changed",
+				},
+			},
+			expectedError: "labels cannot be updated to map[test-key-a:test-value-a test-key-b:test-value-b]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			actualError := test.testData.ValidateUpdate(&originalBinding)
+
+			if test.expectedError == "" {
+				assert.Nil(t, actualError)
+			} else {
+				assert.Contains(t, actualError.Error(), test.expectedError)
+			}
+		})
+	}
+}

--- a/api/v1alpha1/snapshotenvironmentbinding_webhook.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_webhook.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2021-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var snapshotenvironmentbindinglog = logf.Log.WithName("snapshotenvironmentbinding-resource")
+
+func (r *SnapshotEnvironmentBinding) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-appstudio-redhat-com-v1alpha1-snapshotenvironmentbinding,mutating=true,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=snapshotenvironmentbindings,verbs=create;update,versions=v1alpha1,name=msnapshotenvironmentbinding.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &SnapshotEnvironmentBinding{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *SnapshotEnvironmentBinding) Default() {
+	snapshotenvironmentbindinglog.Info("default", "name", r.Name)
+}
+
+// change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-snapshotenvironmentbinding,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=snapshotenvironmentbindings,verbs=create;update,versions=v1alpha1,name=vsnapshotenvironmentbinding.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &SnapshotEnvironmentBinding{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *SnapshotEnvironmentBinding) ValidateCreate() error {
+	snapshotenvironmentbindinglog.Info("validate create", "name", r.Name)
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *SnapshotEnvironmentBinding) ValidateUpdate(old runtime.Object) error {
+	snapshotenvironmentbindinglog.Info("validate update", "name", r.Name)
+
+	switch old := old.(type) {
+	case *SnapshotEnvironmentBinding:
+
+		if !reflect.DeepEqual(r.Labels, old.Labels) {
+			return fmt.Errorf("labels cannot be updated to %+v", r.Labels)
+		}
+
+		if !reflect.DeepEqual(r.Spec.Application, old.Spec.Application) {
+			return fmt.Errorf("application cannot be updated to %+v", r.Spec.Application)
+		}
+
+		if !reflect.DeepEqual(r.Spec.Environment, old.Spec.Environment) {
+			return fmt.Errorf("environment cannot be updated to %+v", r.Spec.Environment)
+		}
+
+	default:
+		return fmt.Errorf("runtime object is not of type SnapshotEnvironmentBinding")
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *SnapshotEnvironmentBinding) ValidateDelete() error {
+	snapshotenvironmentbindinglog.Info("validate delete", "name", r.Name)
+
+	return nil
+}

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -107,6 +107,12 @@ var _ = BeforeSuite(func() {
 	err = (&Snapshot{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&SnapshotEnvironmentBinding{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&PromotionRun{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -45,6 +45,46 @@ webhooks:
     resources:
     - components
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-appstudio-redhat-com-v1alpha1-promotionrun
+  failurePolicy: Fail
+  name: mpromotionrun.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - promotionruns
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-appstudio-redhat-com-v1alpha1-snapshotenvironmentbinding
+  failurePolicy: Fail
+  name: msnapshotenvironmentbinding.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - snapshotenvironmentbindings
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -98,6 +138,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-promotionrun
+  failurePolicy: Fail
+  name: vpromotionrun.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - promotionruns
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-appstudio-redhat-com-v1alpha1-snapshot
   failurePolicy: Fail
   name: vsnapshot.kb.io
@@ -111,4 +171,24 @@ webhooks:
     - UPDATE
     resources:
     - snapshots
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-snapshotenvironmentbinding
+  failurePolicy: Fail
+  name: vsnapshotenvironmentbinding.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - snapshotenvironmentbindings
   sideEffects: None


### PR DESCRIPTION
## Description
This PR is to add webhook for `Snapshot`, `SnapshotEnvironmentBinding` and `PromotionRun` CRs.

Here are the fields monitored by webhook.

**SnapshotEnvironmentBinding**
.metadata.labels
.spec.application 
.spec.environment

**Snapshot**
.spec.application
.spec.components

**ApplicationPromotionRun**
.spec

## Jira ticket
https://issues.redhat.com/browse/GITOPSRVCE-211