### PR TITLE
[DEVHAS-241] Require Application and Component names to conform to DNS-1053

### DIFF
--- a/api/v1alpha1/application_webhook.go
+++ b/api/v1alpha1/application_webhook.go
@@ -58,7 +58,7 @@ func (r *Application) ValidateCreate() error {
 
 	// We use the DNS-1035 format for application names, so ensure it conforms to that specification
 	if len(validation.IsDNS1035Label(r.Name)) != 0 {
-		return fmt.Errorf("invalid component name: %q: a Component resource name must start with a lower case alphabetical character, be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’,", r.Name)
+		return fmt.Errorf("invalid application name: %q: an application resource name must start with a lower case alphabetical character, be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’,", r.Name)
 	}
 	if r.Spec.DisplayName == "" {
 		return fmt.Errorf("display name must be provided when creating an Application")

--- a/api/v1alpha1/application_webhook.go
+++ b/api/v1alpha1/application_webhook.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -55,6 +56,10 @@ var _ webhook.Validator = &Application{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Application) ValidateCreate() error {
 
+	// We use the DNS-1035 format for application names, so ensure it conforms to that specification
+	if len(validation.IsDNS1035Label(r.Name)) != 0 {
+		return fmt.Errorf("invalid component name: %q: a Component resource name must start with a lower case alphabetical character, be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’,", r.Name)
+	}
 	if r.Spec.DisplayName == "" {
 		return fmt.Errorf("display name must be provided when creating an Application")
 	}

--- a/api/v1alpha1/application_webhook_test.go
+++ b/api/v1alpha1/application_webhook_test.go
@@ -71,6 +71,35 @@ var _ = Describe("Application validation webhook", func() {
 		})
 	})
 
+	Context("Create Application CR with invalid metadata.name", func() {
+		It("Should fail with error saying name does not conform to spec", func() {
+			ctx := context.Background()
+
+			hasApp := &Application{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "appstudio.redhat.com/v1alpha1",
+					Kind:       "Application",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "1-invalid-application-name",
+					Namespace: HASAppNamespace,
+				},
+				Spec: ApplicationSpec{
+					AppModelRepository: ApplicationGitRepository{
+						URL: "https://github.com/testorg/petclinic-app",
+					},
+					GitOpsRepository: ApplicationGitRepository{
+						URL: "https://github.com/testorg/gitops-app",
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, hasApp)
+			Expect(err).Should(Not(Succeed()))
+			Expect(err.Error()).Should(ContainSubstring("an application resource name must start with a lower case alphabetical character, be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’"))
+		})
+	})
+
 	Context("Update Application CR fields", func() {
 		It("Should update non immutable fields successfully and err out on immutable fields", func() {
 			ctx := context.Background()

--- a/api/v1alpha1/component_webhook.go
+++ b/api/v1alpha1/component_webhook.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -57,6 +58,10 @@ var _ webhook.Validator = &Component{}
 func (r *Component) ValidateCreate() error {
 	componentlog.Info("validating the create request", "name", r.Name)
 
+	// We use the DNS-1035 format for component names, so ensure it conforms to that specification
+	if len(validation.IsDNS1035Label(r.Name)) != 0 {
+		return fmt.Errorf("invalid component name: %q: a Component resource name must start with a lower case alphabetical character, be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’,", r.Name)
+	}
 	sourceSpecified := false
 
 	if r.Spec.Source.GitSource != nil && r.Spec.Source.GitSource.URL != "" {

--- a/api/v1alpha1/component_webhook.go
+++ b/api/v1alpha1/component_webhook.go
@@ -60,7 +60,7 @@ func (r *Component) ValidateCreate() error {
 
 	// We use the DNS-1035 format for component names, so ensure it conforms to that specification
 	if len(validation.IsDNS1035Label(r.Name)) != 0 {
-		return fmt.Errorf("invalid component name: %q: a Component resource name must start with a lower case alphabetical character, be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’,", r.Name)
+		return fmt.Errorf("invalid component name: %q: a component resource name must start with a lower case alphabetical character, be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’,", r.Name)
 	}
 	sourceSpecified := false
 

--- a/api/v1alpha1/component_webhook_test.go
+++ b/api/v1alpha1/component_webhook_test.go
@@ -46,6 +46,8 @@ var _ = Describe("Application validation webhook", func() {
 
 			uniqueHASCompName := HASCompName + "1"
 
+			badHASCompName := "1-sdsfsdfsdf-bad-name"
+
 			// Bad Component Name, Bad Application Name and no Src
 			hasComp := &Component{
 				TypeMeta: metav1.TypeMeta{
@@ -53,7 +55,6 @@ var _ = Describe("Application validation webhook", func() {
 					Kind:       "Component",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      uniqueHASCompName,
 					Namespace: HASAppNamespace,
 				},
 				Spec: ComponentSpec{
@@ -74,6 +75,13 @@ var _ = Describe("Application validation webhook", func() {
 
 			hasComp.Spec.ComponentName = ComponentName
 			hasComp.Spec.Application = HASAppName
+
+			hasComp.Name = badHASCompName
+			err = k8sClient.Create(ctx, hasComp)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("a component resource name must start with a lower case alphabetical character, be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’"))
+
+			hasComp.Name = uniqueHASCompName
 
 			err = k8sClient.Create(ctx, hasComp)
 			Expect(err).Should(HaveOccurred())

--- a/api/v1alpha1/component_webhook_unit_test.go
+++ b/api/v1alpha1/component_webhook_unit_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestComponentCreateValidatingWebhook(t *testing.T) {
@@ -29,9 +30,25 @@ func TestComponentCreateValidatingWebhook(t *testing.T) {
 		err     string
 	}{
 		{
-			name: "component name cannot be created due to bad URL",
+			name: "component metadata.name is invalid",
+			err:  "invalid component name",
+			newComp: Component{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "1-test-component",
+				},
+				Spec: ComponentSpec{
+					ComponentName: "component1",
+					Application:   "application1",
+				},
+			},
+		},
+		{
+			name: "component cannot be created due to bad URL",
 			err:  "invalid URI for request",
 			newComp: Component{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-component",
+				},
 				Spec: ComponentSpec{
 					ComponentName: "component1",
 					Application:   "application1",
@@ -49,6 +66,9 @@ func TestComponentCreateValidatingWebhook(t *testing.T) {
 			name: "component needs to have one source specified",
 			err:  "git source or an image source must be specified",
 			newComp: Component{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-component",
+				},
 				Spec: ComponentSpec{
 					ComponentName: "component1",
 					Application:   "application1",
@@ -63,6 +83,9 @@ func TestComponentCreateValidatingWebhook(t *testing.T) {
 		{
 			name: "valid component with git src",
 			newComp: Component{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-component",
+				},
 				Spec: ComponentSpec{
 					ComponentName: "component1",
 					Application:   "application1",
@@ -79,6 +102,9 @@ func TestComponentCreateValidatingWebhook(t *testing.T) {
 		{
 			name: "valid component with container image",
 			newComp: Component{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test-component",
+				},
 				Spec: ComponentSpec{
 					ComponentName:  "component1",
 					Application:    "application1",
@@ -103,6 +129,9 @@ func TestComponentCreateValidatingWebhook(t *testing.T) {
 func TestComponentUpdateValidatingWebhook(t *testing.T) {
 
 	originalComponent := Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-component",
+		},
 		Spec: ComponentSpec{
 			ComponentName: "component",
 			Application:   "application",


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVHAS-241

Updates the webhook validation for Application and Component CR names to ensure they conform to the DNS-1053 specification.