### PR TITLE
Add omitempty to Type field of Environment spec

### DIFF
--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -24,7 +24,7 @@ import (
 type EnvironmentSpec struct {
 
 	// Type is whether the Environment is a POC or non-POC environment
-	Type EnvironmentType `json:"type"`
+	Type EnvironmentType `json:"type,omitempty"`
 
 	// DisplayName is the user-visible, user-definable name for the environment (but not used for functional requirements)
 	DisplayName string `json:"displayName"`

--- a/config/crd/bases/appstudio.redhat.com_environments.yaml
+++ b/config/crd/bases/appstudio.redhat.com_environments.yaml
@@ -126,7 +126,6 @@ spec:
             required:
             - deploymentStrategy
             - displayName
-            - type
             type: object
           status:
             description: EnvironmentStatus defines the observed state of Environment

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -1116,7 +1116,6 @@ spec:
             required:
             - deploymentStrategy
             - displayName
-            - type
             type: object
           status:
             description: EnvironmentStatus defines the observed state of Environment


### PR DESCRIPTION
Environment's .spec.Type field is  optional so added omitempty to this field

JIRA ticket - https://issues.redhat.com/browse/GITOPSRVCE-356