### PR TITLE
Remove workflow job to install KCP tooling

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,11 +51,6 @@ jobs:
           mkdir -p ~/bin
           cp ~/cache/operator-sdk-${OPERATOR_SDK_VERSION} ~/bin/operator-sdk
           echo "$HOME/bin" >> $GITHUB_PATH
-      - name: Install kcp tooling
-        run: |
-          git clone https://github.com/kcp-dev/kcp ~/kcp
-          cd ~/kcp
-          WHAT=./cmd/kubectl-kcp make install
       - name: Cache go modules
         id: cache-mod
         uses: actions/cache@v2


### PR DESCRIPTION
Since we have paused supporting KCP, we can disable the workflow job for installing KCP.