### PR TITLE
STONEBLD-777 - tekton-ci: update bundle

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -36,5 +36,5 @@ spec:
       - name: SCRIPT
         value: $(params.infra-deployment-update-script)
       taskRef:
-        bundle: quay.io/redhat-appstudio/appstudio-tasks:748a03507b68aa610212e8031e3301ab943a14ef-2
+        bundle: quay.io/redhat-appstudio-tekton-catalog/task-update-infra-deployments:0.1
         name: update-infra-deployments


### PR DESCRIPTION
Switching to new bundle since development of old one was stopped before attempt to migrate to kcp. New bundle is removing dependency on shared secret.