### PR TITLE
[DEVHAS-180] update gitsource URL description

### DIFF
--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -33,7 +33,7 @@ const (
 )
 
 type GitSource struct {
-	// If importing from git, the repository to create the component from
+	// An HTTPS URL representing the git repository to create the component from.
 	URL string `json:"url"`
 
 	// Specify a branch/tag/commit id. If not specified, default is `main`/`master`.

--- a/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
+++ b/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
@@ -74,8 +74,8 @@ spec:
                       default is `main`/`master`. Example: devel. Optional.'
                     type: string
                   url:
-                    description: If importing from git, the repository to create the
-                      component from
+                    description: An HTTPS URL representing the git repository to create
+                      the component from.
                     type: string
                 required:
                 - url
@@ -312,8 +312,8 @@ spec:
                                     devel. Optional.'
                                   type: string
                                 url:
-                                  description: If importing from git, the repository
-                                    to create the component from
+                                  description: An HTTPS URL representing the git repository
+                                    to create the component from.
                                   type: string
                               required:
                               - url

--- a/config/crd/bases/appstudio.redhat.com_components.yaml
+++ b/config/crd/bases/appstudio.redhat.com_components.yaml
@@ -245,8 +245,8 @@ spec:
                           default is `main`/`master`. Example: devel. Optional.'
                         type: string
                       url:
-                        description: If importing from git, the repository to create
-                          the component from
+                        description: An HTTPS URL representing the git repository
+                          to create the component from.
                         type: string
                     required:
                     - url

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -268,8 +268,8 @@ spec:
                       default is `main`/`master`. Example: devel. Optional.'
                     type: string
                   url:
-                    description: If importing from git, the repository to create the
-                      component from
+                    description: An HTTPS URL representing the git repository to create
+                      the component from.
                     type: string
                 required:
                 - url
@@ -506,8 +506,8 @@ spec:
                                     devel. Optional.'
                                   type: string
                                 url:
-                                  description: If importing from git, the repository
-                                    to create the component from
+                                  description: An HTTPS URL representing the git repository
+                                    to create the component from.
                                   type: string
                               required:
                               - url
@@ -861,8 +861,8 @@ spec:
                           default is `main`/`master`. Example: devel. Optional.'
                         type: string
                       url:
-                        description: If importing from git, the repository to create
-                          the component from
+                        description: An HTTPS URL representing the git repository
+                          to create the component from.
                         type: string
                     required:
                     - url


### PR DESCRIPTION
Update API docs to make it clear that we are expecting an HTTPS URL
https://issues.redhat.com/browse/DEVHAS-180