### PR TITLE
GitOps: Add sync/health/commitID to Snapshot Env Binding (#199)

### DIFF
--- a/api/v1alpha1/snapshotenvironmentbinding_types.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_types.go
@@ -168,8 +168,17 @@ type BindingStatusGitOpsDeployment struct {
 	ComponentName string `json:"componentName"`
 
 	// GitOpsDeployment is a reference to the name of a GitOpsDeployment resource which is used to deploy the binding.
-	// The Health/sync status for the binding can thus be read from the references GitOpsDEployment
+	// The Health/sync status for the binding can thus be read from the references GitOpsDeployment
 	GitOpsDeployment string `json:"gitopsDeployment,omitempty"`
+
+	// GitOpsDeploymentSyncStatus is the sync status of the deployment owned by the binding
+	GitOpsDeploymentSyncStatus string `json:"syncStatus,omitempty"`
+
+	// GitOpsDeploymentHealthStatus is the health status of the deployment owned by the binding
+	GitOpsDeploymentHealthStatus string `json:"health,omitempty"`
+
+	// GitOpsDeploymentCommitID is the commit ID of the GitOpsDeployment
+	GitOpsDeploymentCommitID string `json:"commitID,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/appstudio.redhat.com_snapshotenvironmentbindings.yaml
+++ b/config/crd/bases/appstudio.redhat.com_snapshotenvironmentbindings.yaml
@@ -338,6 +338,10 @@ spec:
                     this binding. \n To determine the health/sync status of a binding,
                     you can look at the GitOpsDeployments decribed here."
                   properties:
+                    commitID:
+                      description: GitOpsDeploymentCommitID is the commit ID of the
+                        GitOpsDeployment
+                      type: string
                     componentName:
                       description: ComponentName is the name of the component in the
                         (component, gitopsdeployment) pair
@@ -346,7 +350,15 @@ spec:
                       description: GitOpsDeployment is a reference to the name of
                         a GitOpsDeployment resource which is used to deploy the binding.
                         The Health/sync status for the binding can thus be read from
-                        the references GitOpsDEployment
+                        the references GitOpsDeployment
+                      type: string
+                    health:
+                      description: GitOpsDeploymentHealthStatus is the health status
+                        of the deployment owned by the binding
+                      type: string
+                    syncStatus:
+                      description: GitOpsDeploymentSyncStatus is the sync status of
+                        the deployment owned by the binding
                       type: string
                   required:
                   - componentName

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -1639,6 +1639,10 @@ spec:
                     this binding. \n To determine the health/sync status of a binding,
                     you can look at the GitOpsDeployments decribed here."
                   properties:
+                    commitID:
+                      description: GitOpsDeploymentCommitID is the commit ID of the
+                        GitOpsDeployment
+                      type: string
                     componentName:
                       description: ComponentName is the name of the component in the
                         (component, gitopsdeployment) pair
@@ -1647,7 +1651,15 @@ spec:
                       description: GitOpsDeployment is a reference to the name of
                         a GitOpsDeployment resource which is used to deploy the binding.
                         The Health/sync status for the binding can thus be read from
-                        the references GitOpsDEployment
+                        the references GitOpsDeployment
+                      type: string
+                    health:
+                      description: GitOpsDeploymentHealthStatus is the health status
+                        of the deployment owned by the binding
+                      type: string
+                    syncStatus:
+                      description: GitOpsDeploymentSyncStatus is the sync status of
+                        the deployment owned by the binding
                       type: string
                   required:
                   - componentName


### PR DESCRIPTION
See GITOPSRVCE-199

FYI: @jgwest

Notes to reviewer: 
- ran make targets: build, fmt, lint, generate, manifests
- feel free to change comments to your liking
- Did not run target: manifests-kcp