### PR TITLE
Remove SnapshotEnvironmentBinding validation for labels.

### DIFF
--- a/api/v1alpha1/snapshotenvironmentbinding_webhook unit_test.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_webhook unit_test.go
@@ -81,37 +81,6 @@ func TestSnapshotEnvironmentBindingValidatingWebhook(t *testing.T) {
 			},
 			expectedError: "environment cannot be updated to test-env-a-changed",
 		},
-
-		{
-			testName: "Error occurs when existing label is changed.",
-			testData: SnapshotEnvironmentBinding{
-				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{"test-key-a": "test-value-b"},
-				},
-				Spec: SnapshotEnvironmentBindingSpec{
-					Application: "test-app-a",
-					Environment: "test-env-a-changed",
-				},
-			},
-			expectedError: "labels cannot be updated to map[test-key-a:test-value-b]",
-		},
-
-		{
-			testName: "Error occurs when new label is added.",
-			testData: SnapshotEnvironmentBinding{
-				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{
-						"test-key-a": "test-value-a",
-						"test-key-b": "test-value-b",
-					},
-				},
-				Spec: SnapshotEnvironmentBindingSpec{
-					Application: "test-app-a",
-					Environment: "test-env-a-changed",
-				},
-			},
-			expectedError: "labels cannot be updated to map[test-key-a:test-value-a test-key-b:test-value-b]",
-		},
 	}
 
 	for _, test := range tests {

--- a/api/v1alpha1/snapshotenvironmentbinding_webhook.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_webhook.go
@@ -62,11 +62,6 @@ func (r *SnapshotEnvironmentBinding) ValidateUpdate(old runtime.Object) error {
 
 	switch old := old.(type) {
 	case *SnapshotEnvironmentBinding:
-
-		if !reflect.DeepEqual(r.Labels, old.Labels) {
-			return fmt.Errorf("labels cannot be updated to %+v", r.Labels)
-		}
-
 		if !reflect.DeepEqual(r.Spec.Application, old.Spec.Application) {
 			return fmt.Errorf("application cannot be updated to %+v", r.Spec.Application)
 		}


### PR DESCRIPTION
## Description

This PR is to remove webhook validation for SnapshotEnvironmentBinding labels as it is not needed anymore. 

