### PR TITLE
Update API doc to clarify DevfileURL and DockerfileURL can be local

### DIFF
--- a/api/v1alpha1/component_types.go
+++ b/api/v1alpha1/component_types.go
@@ -46,12 +46,12 @@ type GitSource struct {
 	// Optional.
 	Context string `json:"context,omitempty"`
 
-	// If specified, the devfile at the URL will be used for the component.
+	// If specified, the devfile at the URI will be used for the component. Can be a local path inside the repository, or an external URL.
 	// Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
 	// Optional.
 	DevfileURL string `json:"devfileUrl,omitempty"`
 
-	// If specified, the dockerfile at the URL will be used for the component.
+	// If specified, the dockerfile at the URI will be used for the component. Can be a local path inside the repository, or an external URL.
 	// Optional.
 	DockerfileURL string `json:"dockerfileUrl,omitempty"`
 }

--- a/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
+++ b/config/crd/bases/appstudio.redhat.com_componentdetectionqueries.yaml
@@ -61,13 +61,15 @@ spec:
                       component Example: folderA/folderB/gitops. Optional.'
                     type: string
                   devfileUrl:
-                    description: 'If specified, the devfile at the URL will be used
-                      for the component. Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
+                    description: 'If specified, the devfile at the URI will be used
+                      for the component. Can be a local path inside the repository,
+                      or an external URL. Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
                       Optional.'
                     type: string
                   dockerfileUrl:
-                    description: If specified, the dockerfile at the URL will be used
-                      for the component. Optional.
+                    description: If specified, the dockerfile at the URI will be used
+                      for the component. Can be a local path inside the repository,
+                      or an external URL. Optional.
                     type: string
                   revision:
                     description: 'Specify a branch/tag/commit id. If not specified,
@@ -298,13 +300,17 @@ spec:
                                     Optional.'
                                   type: string
                                 devfileUrl:
-                                  description: 'If specified, the devfile at the URL
-                                    will be used for the component. Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
+                                  description: 'If specified, the devfile at the URI
+                                    will be used for the component. Can be a local
+                                    path inside the repository, or an external URL.
+                                    Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
                                     Optional.'
                                   type: string
                                 dockerfileUrl:
                                   description: If specified, the dockerfile at the
-                                    URL will be used for the component. Optional.
+                                    URI will be used for the component. Can be a local
+                                    path inside the repository, or an external URL.
+                                    Optional.
                                   type: string
                                 revision:
                                   description: 'Specify a branch/tag/commit id. If

--- a/config/crd/bases/appstudio.redhat.com_components.yaml
+++ b/config/crd/bases/appstudio.redhat.com_components.yaml
@@ -232,13 +232,15 @@ spec:
                           the component Example: folderA/folderB/gitops. Optional.'
                         type: string
                       devfileUrl:
-                        description: 'If specified, the devfile at the URL will be
-                          used for the component. Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
+                        description: 'If specified, the devfile at the URI will be
+                          used for the component. Can be a local path inside the repository,
+                          or an external URL. Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
                           Optional.'
                         type: string
                       dockerfileUrl:
-                        description: If specified, the dockerfile at the URL will
-                          be used for the component. Optional.
+                        description: If specified, the dockerfile at the URI will
+                          be used for the component. Can be a local path inside the
+                          repository, or an external URL. Optional.
                         type: string
                       revision:
                         description: 'Specify a branch/tag/commit id. If not specified,

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -255,13 +255,15 @@ spec:
                       component Example: folderA/folderB/gitops. Optional.'
                     type: string
                   devfileUrl:
-                    description: 'If specified, the devfile at the URL will be used
-                      for the component. Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
+                    description: 'If specified, the devfile at the URI will be used
+                      for the component. Can be a local path inside the repository,
+                      or an external URL. Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
                       Optional.'
                     type: string
                   dockerfileUrl:
-                    description: If specified, the dockerfile at the URL will be used
-                      for the component. Optional.
+                    description: If specified, the dockerfile at the URI will be used
+                      for the component. Can be a local path inside the repository,
+                      or an external URL. Optional.
                     type: string
                   revision:
                     description: 'Specify a branch/tag/commit id. If not specified,
@@ -492,13 +494,17 @@ spec:
                                     Optional.'
                                   type: string
                                 devfileUrl:
-                                  description: 'If specified, the devfile at the URL
-                                    will be used for the component. Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
+                                  description: 'If specified, the devfile at the URI
+                                    will be used for the component. Can be a local
+                                    path inside the repository, or an external URL.
+                                    Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
                                     Optional.'
                                   type: string
                                 dockerfileUrl:
                                   description: If specified, the dockerfile at the
-                                    URL will be used for the component. Optional.
+                                    URI will be used for the component. Can be a local
+                                    path inside the repository, or an external URL.
+                                    Optional.
                                   type: string
                                 revision:
                                   description: 'Specify a branch/tag/commit id. If
@@ -848,13 +854,15 @@ spec:
                           the component Example: folderA/folderB/gitops. Optional.'
                         type: string
                       devfileUrl:
-                        description: 'If specified, the devfile at the URL will be
-                          used for the component. Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
+                        description: 'If specified, the devfile at the URI will be
+                          used for the component. Can be a local path inside the repository,
+                          or an external URL. Example: https://raw.githubusercontent.com/devfile-samples/devfile-sample-java-springboot-basic/main/devfile.yaml.
                           Optional.'
                         type: string
                       dockerfileUrl:
-                        description: If specified, the dockerfile at the URL will
-                          be used for the component. Optional.
+                        description: If specified, the dockerfile at the URI will
+                          be used for the component. Can be a local path inside the
+                          repository, or an external URL. Optional.
                         type: string
                       revision:
                         description: 'Specify a branch/tag/commit id. If not specified,


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/DEVHAS-228 and https://issues.redhat.com/browse/DEVHAS-274, a local URI will be returned in the Component stub, when a detected Component has a Dockerfile present in the repository. Previously, an absolute URI would always be returned. This PR is updating the description to clarify that in addition to external URLs being allowed, the `dockerfileURL` field can also point to a local URI within the repository (e.g. `./docker/Dockerfile`).

Since we're already doing the same for locally-detected devfiles, I also updated the API spec for `devfileURL` as well.

To avoid API breakages, we are leaving the field names as `dockerfileURL` and `devfileURL` for the time being.