### PR TITLE
Add skip TLS verify field to DeploymentTarget cluster credentials

### DIFF
--- a/api/v1alpha1/deploymenttarget_types.go
+++ b/api/v1alpha1/deploymenttarget_types.go
@@ -40,6 +40,9 @@ type DeploymentTargetKubernetesClusterCredentials struct {
 
 	// ClusterCredentialsSecret is a reference to the name of k8s Secret that contains a kubeconfig.
 	ClusterCredentialsSecret string `json:"clusterCredentialsSecret"`
+
+	// Indicates that a Service should not check the TLS certificate when connecting to this target.
+	AllowInsecureSkipTLSVerify bool `json:"allowInsecureSkipTLSVerify"`
 }
 
 // DeploymentTargetStatus defines the observed state of DeploymentTarget

--- a/config/crd/bases/appstudio.redhat.com_deploymenttargets.yaml
+++ b/config/crd/bases/appstudio.redhat.com_deploymenttargets.yaml
@@ -46,6 +46,10 @@ spec:
                 description: DeploymentTargetKubernetesClusterCredentials defines
                   the K8s cluster credentials for the DeploymentTarget.
                 properties:
+                  allowInsecureSkipTLSVerify:
+                    description: Indicates that a Service should not check the TLS
+                      certificate when connecting to this target.
+                    type: boolean
                   apiURL:
                     description: APIURL is a reference to a cluster API url.
                     type: string
@@ -56,6 +60,7 @@ spec:
                   defaultNamespace:
                     type: string
                 required:
+                - allowInsecureSkipTLSVerify
                 - apiURL
                 - clusterCredentialsSecret
                 - defaultNamespace

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -1165,6 +1165,10 @@ spec:
                 description: DeploymentTargetKubernetesClusterCredentials defines
                   the K8s cluster credentials for the DeploymentTarget.
                 properties:
+                  allowInsecureSkipTLSVerify:
+                    description: Indicates that a Service should not check the TLS
+                      certificate when connecting to this target.
+                    type: boolean
                   apiURL:
                     description: APIURL is a reference to a cluster API url.
                     type: string
@@ -1175,6 +1179,7 @@ spec:
                   defaultNamespace:
                     type: string
                 required:
+                - allowInsecureSkipTLSVerify
                 - apiURL
                 - clusterCredentialsSecret
                 - defaultNamespace


### PR DESCRIPTION
* Services can skip TLS verification when connecting to this target
* This value will be mapped to the `allowInsecureSkipTLSVerify` field of GitOpsDeploymentManagedEnvironment