### PR TITLE
Add type field to Environment configuration, indicating Kubernetes vs OpenShift

### DIFF
--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -23,7 +23,7 @@ import (
 // EnvironmentSpec defines the desired state of Environment
 type EnvironmentSpec struct {
 
-	// Type is whether the Environment is a POC or non-POC environment
+	// DEPRECATED: Type is whether the Environment is a POC or non-POC environment
 	// - This field is deprecated, and should not be used.
 	Type EnvironmentType `json:"type,omitempty"`
 
@@ -51,11 +51,15 @@ type EnvironmentSpec struct {
 	UnstableConfigurationFields *UnstableEnvironmentConfiguration `json:"unstableConfigurationFields,omitempty"`
 }
 
-// EnvironmentType currently indicates whether an environment is POC/Non-POC, see API doc for details.
+// DEPRECATED: EnvironmentType should no longer be used, and has no replacement.
+// - It's original purpose was to indicate whether an environment is POC/Non-POC, but these data were ultimately not required.
 type EnvironmentType string
 
 const (
-	EnvironmentType_POC    EnvironmentType = "POC"
+	// DEPRECATED: EnvironmentType_POC should no longer be used, and has no replacement.
+	EnvironmentType_POC EnvironmentType = "POC"
+
+	// EnvironmentType_NonPOC should no longer be used, and has no replacement.
 	EnvironmentType_NonPOC EnvironmentType = "Non-POC"
 )
 
@@ -79,10 +83,24 @@ const (
 // Note: as of this writing (Jul 2022), I expect the contents of this struct to undergo major changes, and the API should not be considered
 // complete, or even a reflection of final desired state.
 type UnstableEnvironmentConfiguration struct {
+	// EnvironmentType indicates whether the target environment is Kubernetes or OpenShift
+	EnvironmentType ConfigurationEnvironmentType `json:"environmentType,omitempty"`
+
+	// KubernetesClusterCredentials contains cluster credentials for a target Kubernetes/OpenShift cluster.
 	KubernetesClusterCredentials `json:"kubernetesCredentials,omitempty"`
 }
 
-// KubernetesClusterCredentials allows you to specify cluster credentials for stanadard K8s cluster (e.g. non-KCP workspace).
+type ConfigurationEnvironmentType string
+
+const (
+	// ConfigurationEnvironmentType_Kubernetes indicates the target environment is generic Kubernetes
+	ConfigurationEnvironmentType_Kubernetes ConfigurationEnvironmentType = "Kubernetes"
+
+	// ConfigurationEnvironmentType_OpenShift indicates the target environment is OpenShift
+	ConfigurationEnvironmentType_OpenShift ConfigurationEnvironmentType = "OpenShift"
+)
+
+// KubernetesClusterCredentials contains cluster credentials for a target Kubernetes/OpenShift cluster.
 //
 // See this temporary URL for details on what values to provide for the APIURL and Secret:
 // https://github.com/redhat-appstudio/managed-gitops/tree/main/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource

--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -59,7 +59,7 @@ const (
 	// DEPRECATED: EnvironmentType_POC should no longer be used, and has no replacement.
 	EnvironmentType_POC EnvironmentType = "POC"
 
-	// EnvironmentType_NonPOC should no longer be used, and has no replacement.
+	// DEPRECATED: EnvironmentType_NonPOC should no longer be used, and has no replacement.
 	EnvironmentType_NonPOC EnvironmentType = "Non-POC"
 )
 

--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -83,21 +83,21 @@ const (
 // Note: as of this writing (Jul 2022), I expect the contents of this struct to undergo major changes, and the API should not be considered
 // complete, or even a reflection of final desired state.
 type UnstableEnvironmentConfiguration struct {
-	// EnvironmentType indicates whether the target environment is Kubernetes or OpenShift
-	EnvironmentType ConfigurationEnvironmentType `json:"environmentType,omitempty"`
+	// ClusterType indicates whether the target environment is Kubernetes or OpenShift
+	ClusterType ConfigurationClusterType `json:"clusterType,omitempty"`
 
 	// KubernetesClusterCredentials contains cluster credentials for a target Kubernetes/OpenShift cluster.
 	KubernetesClusterCredentials `json:"kubernetesCredentials,omitempty"`
 }
 
-type ConfigurationEnvironmentType string
+type ConfigurationClusterType string
 
 const (
-	// ConfigurationEnvironmentType_Kubernetes indicates the target environment is generic Kubernetes
-	ConfigurationEnvironmentType_Kubernetes ConfigurationEnvironmentType = "Kubernetes"
+	// ConfigurationClusterType_Kubernetes indicates the target environment is generic Kubernetes
+	ConfigurationClusterType_Kubernetes ConfigurationClusterType = "Kubernetes"
 
-	// ConfigurationEnvironmentType_OpenShift indicates the target environment is OpenShift
-	ConfigurationEnvironmentType_OpenShift ConfigurationEnvironmentType = "OpenShift"
+	// ConfigurationClusterType_OpenShift indicates the target environment is OpenShift
+	ConfigurationClusterType_OpenShift ConfigurationClusterType = "OpenShift"
 )
 
 // KubernetesClusterCredentials contains cluster credentials for a target Kubernetes/OpenShift cluster.

--- a/config/crd/bases/appstudio.redhat.com_environments.yaml
+++ b/config/crd/bases/appstudio.redhat.com_environments.yaml
@@ -100,19 +100,22 @@ spec:
                   type: string
                 type: array
               type:
-                description: Type is whether the Environment is a POC or non-POC environment
-                  - This field is deprecated, and should not be used.
+                description: 'DEPRECATED: Type is whether the Environment is a POC
+                  or non-POC environment - This field is deprecated, and should not
+                  be used.'
                 type: string
               unstableConfigurationFields:
                 description: 'UnstableConfigurationFields are experimental/prototype:
                   the API has not been finalized here, and is subject to breaking
                   changes. See comment on UnstableEnvironmentConfiguration for details.'
                 properties:
+                  environmentType:
+                    description: EnvironmentType indicates whether the target environment
+                      is Kubernetes or OpenShift
+                    type: string
                   kubernetesCredentials:
-                    description: "KubernetesClusterCredentials allows you to specify
-                      cluster credentials for stanadard K8s cluster (e.g. non-KCP
-                      workspace). \n See this temporary URL for details on what values
-                      to provide for the APIURL and Secret: https://github.com/redhat-appstudio/managed-gitops/tree/main/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource"
+                    description: KubernetesClusterCredentials contains cluster credentials
+                      for a target Kubernetes/OpenShift cluster.
                     properties:
                       allowInsecureSkipTLSVerify:
                         description: Indicates that ArgoCD/GitOps Service should not

--- a/config/crd/bases/appstudio.redhat.com_environments.yaml
+++ b/config/crd/bases/appstudio.redhat.com_environments.yaml
@@ -109,8 +109,8 @@ spec:
                   the API has not been finalized here, and is subject to breaking
                   changes. See comment on UnstableEnvironmentConfiguration for details.'
                 properties:
-                  environmentType:
-                    description: EnvironmentType indicates whether the target environment
+                  clusterType:
+                    description: ClusterType indicates whether the target environment
                       is Kubernetes or OpenShift
                     type: string
                   kubernetesCredentials:

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -1305,19 +1305,22 @@ spec:
                   type: string
                 type: array
               type:
-                description: Type is whether the Environment is a POC or non-POC environment
-                  - This field is deprecated, and should not be used.
+                description: 'DEPRECATED: Type is whether the Environment is a POC
+                  or non-POC environment - This field is deprecated, and should not
+                  be used.'
                 type: string
               unstableConfigurationFields:
                 description: 'UnstableConfigurationFields are experimental/prototype:
                   the API has not been finalized here, and is subject to breaking
                   changes. See comment on UnstableEnvironmentConfiguration for details.'
                 properties:
+                  environmentType:
+                    description: EnvironmentType indicates whether the target environment
+                      is Kubernetes or OpenShift
+                    type: string
                   kubernetesCredentials:
-                    description: "KubernetesClusterCredentials allows you to specify
-                      cluster credentials for stanadard K8s cluster (e.g. non-KCP
-                      workspace). \n See this temporary URL for details on what values
-                      to provide for the APIURL and Secret: https://github.com/redhat-appstudio/managed-gitops/tree/main/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource"
+                    description: KubernetesClusterCredentials contains cluster credentials
+                      for a target Kubernetes/OpenShift cluster.
                     properties:
                       allowInsecureSkipTLSVerify:
                         description: Indicates that ArgoCD/GitOps Service should not

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -1314,8 +1314,8 @@ spec:
                   the API has not been finalized here, and is subject to breaking
                   changes. See comment on UnstableEnvironmentConfiguration for details.'
                 properties:
-                  environmentType:
-                    description: EnvironmentType indicates whether the target environment
+                  clusterType:
+                    description: ClusterType indicates whether the target environment
                       is Kubernetes or OpenShift
                     type: string
                   kubernetesCredentials:


### PR DESCRIPTION
As discussed on [RHTAP-129/STONE-264](https://docs.google.com/document/d/1ihFNBy3FsW3R3Jyt9zLAM6TpIGYH2tkFmFZTiD2rsBw/edit#heading=h.5o6ujoz34zty) we need a field to describe whether the target K8s environment is Kubernetes or OpenShift. 

This is a first stab at such a field, feel free to provide comments on the PR.

