### PR TITLE
Fix excessive Environment API log key/values in webhook logs

### DIFF
--- a/api/v1alpha1/promotionrun_webhook.go
+++ b/api/v1alpha1/promotionrun_webhook.go
@@ -41,7 +41,7 @@ var _ webhook.Defaulter = &PromotionRun{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *PromotionRun) Default() {
-	promotionrunlog = promotionrunlog.WithValues("controllerKind", "PromotionRun").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	promotionrunlog := promotionrunlog.WithValues("controllerKind", "PromotionRun").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
 	promotionrunlog.Info("default")
 }
 
@@ -52,16 +52,16 @@ var _ webhook.Validator = &PromotionRun{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *PromotionRun) ValidateCreate() error {
-	promotionrunlog = promotionrunlog.WithValues("controllerKind", "PromotionRun").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
-	promotionrunlog.Info("validat create")
+	promotionrunlog := promotionrunlog.WithValues("controllerKind", "PromotionRun").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	promotionrunlog.Info("validating create")
 
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *PromotionRun) ValidateUpdate(old runtime.Object) error {
-	promotionrunlog = promotionrunlog.WithValues("controllerKind", "PromotionRun").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
-	promotionrunlog.Info("validate update")
+	promotionrunlog := promotionrunlog.WithValues("controllerKind", "PromotionRun").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	promotionrunlog.Info("validating update")
 
 	switch old := old.(type) {
 	case *PromotionRun:
@@ -79,8 +79,8 @@ func (r *PromotionRun) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *PromotionRun) ValidateDelete() error {
-	promotionrunlog = promotionrunlog.WithValues("controllerKind", "PromotionRun").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
-	promotionrunlog.Info("validate delete")
+	promotionrunlog := promotionrunlog.WithValues("controllerKind", "PromotionRun").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	promotionrunlog.Info("validating delete")
 
 	return nil
 }

--- a/api/v1alpha1/snapshot_webhook unit_test.go
+++ b/api/v1alpha1/snapshot_webhook unit_test.go
@@ -63,22 +63,17 @@ func TestSnapshotValidatingWebhook(t *testing.T) {
 			testData: Snapshot{
 				Spec: SnapshotSpec{
 					Application: "test-app-a-changed",
-					Components: []SnapshotComponent{
-						{
-							Name:           "test-component-a",
-							ContainerImage: "test-container-image-a",
-						},
-					},
+					Components:  originalSnapshot.Spec.Components,
 				},
 			},
-			expectedError: "application cannot be updated to test-app-a-changed",
+			expectedError: "application field cannot be updated to test-app-a-changed",
 		},
 
 		{
 			testName: "Error occurs when Spec.Components.Name is changed.",
 			testData: Snapshot{
 				Spec: SnapshotSpec{
-					Application: "test-app-a",
+					Application: originalSnapshot.Spec.Application,
 					Components: []SnapshotComponent{
 						{
 							Name:           "test-component-a-changed",

--- a/api/v1alpha1/snapshot_webhook.go
+++ b/api/v1alpha1/snapshot_webhook.go
@@ -42,16 +42,16 @@ var _ webhook.Validator = &Snapshot{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Snapshot) ValidateCreate() error {
-	snapshotlog = promotionrunlog.WithValues("controllerKind", "Snapshot").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
-	snapshotlog.Info("validate create")
+	snapshotlog := snapshotlog.WithValues("controllerKind", "Snapshot").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	snapshotlog.Info("validating create")
 
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Snapshot) ValidateUpdate(old runtime.Object) error {
-	snapshotlog = promotionrunlog.WithValues("controllerKind", "Snapshot").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
-	snapshotlog.Info("validate update")
+	snapshotlog := snapshotlog.WithValues("controllerKind", "Snapshot").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	snapshotlog.Info("validating update")
 
 	switch old := old.(type) {
 	case *Snapshot:
@@ -73,8 +73,8 @@ func (r *Snapshot) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *Snapshot) ValidateDelete() error {
-	snapshotlog = promotionrunlog.WithValues("controllerKind", "Snapshot").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
-	snapshotlog.Info("validate delete")
+	snapshotlog := snapshotlog.WithValues("controllerKind", "Snapshot").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	snapshotlog.Info("validating delete")
 
 	return nil
 }

--- a/api/v1alpha1/snapshot_webhook.go
+++ b/api/v1alpha1/snapshot_webhook.go
@@ -57,7 +57,7 @@ func (r *Snapshot) ValidateUpdate(old runtime.Object) error {
 	case *Snapshot:
 
 		if !reflect.DeepEqual(r.Spec.Application, old.Spec.Application) {
-			return fmt.Errorf("application cannot be updated to %+v", r.Spec.Application)
+			return fmt.Errorf("application field cannot be updated to %+v", r.Spec.Application)
 		}
 
 		if !reflect.DeepEqual(r.Spec.Components, old.Spec.Components) {

--- a/api/v1alpha1/snapshotenvironmentbinding_webhook unit_test.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_webhook unit_test.go
@@ -65,7 +65,7 @@ func TestSnapshotEnvironmentBindingValidatingWebhook(t *testing.T) {
 					Environment: "test-env-a",
 				},
 			},
-			expectedError: "application cannot be updated to test-app-a-changed",
+			expectedError: "application field cannot be updated to test-app-a-changed",
 		},
 
 		{
@@ -79,7 +79,7 @@ func TestSnapshotEnvironmentBindingValidatingWebhook(t *testing.T) {
 					Environment: "test-env-a-changed",
 				},
 			},
-			expectedError: "environment cannot be updated to test-env-a-changed",
+			expectedError: "environment field cannot be updated to test-env-a-changed",
 		},
 	}
 

--- a/api/v1alpha1/snapshotenvironmentbinding_webhook.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_webhook.go
@@ -41,7 +41,7 @@ var _ webhook.Defaulter = &SnapshotEnvironmentBinding{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *SnapshotEnvironmentBinding) Default() {
-	snapshotenvironmentbindinglog = snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	snapshotenvironmentbindinglog := snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
 	snapshotenvironmentbindinglog.Info("default", "name", r.Name)
 }
 
@@ -52,25 +52,25 @@ var _ webhook.Validator = &SnapshotEnvironmentBinding{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *SnapshotEnvironmentBinding) ValidateCreate() error {
-	snapshotenvironmentbindinglog = snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
-	snapshotenvironmentbindinglog.Info("validate create")
+	snapshotenvironmentbindinglog := snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	snapshotenvironmentbindinglog.Info("validating create")
 
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *SnapshotEnvironmentBinding) ValidateUpdate(old runtime.Object) error {
-	snapshotenvironmentbindinglog = snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
-	snapshotenvironmentbindinglog.Info("validate update")
+	snapshotenvironmentbindinglog := snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	snapshotenvironmentbindinglog.Info("validating update")
 
 	switch old := old.(type) {
 	case *SnapshotEnvironmentBinding:
 		if !reflect.DeepEqual(r.Spec.Application, old.Spec.Application) {
-			return fmt.Errorf("application cannot be updated to %+v", r.Spec.Application)
+			return fmt.Errorf("application field cannot be updated to %+v", r.Spec.Application)
 		}
 
 		if !reflect.DeepEqual(r.Spec.Environment, old.Spec.Environment) {
-			return fmt.Errorf("environment cannot be updated to %+v", r.Spec.Environment)
+			return fmt.Errorf("environment field cannot be updated to %+v", r.Spec.Environment)
 		}
 
 	default:
@@ -82,8 +82,8 @@ func (r *SnapshotEnvironmentBinding) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *SnapshotEnvironmentBinding) ValidateDelete() error {
-	snapshotenvironmentbindinglog = snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
-	snapshotenvironmentbindinglog.Info("validate delete")
+	snapshotenvironmentbindinglog := snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	snapshotenvironmentbindinglog.Info("validating delete")
 
 	return nil
 }


### PR DESCRIPTION
I'm seeing this monstrosity (:grin:) in the appliction controller webhook logs:
`
2023-04-25T19:44:06.265001341Z	INFO	snapshotenvironmentbinding-resource	validate update	{"controllerKind": "SnapshotEnvironmentBinding", "name": "tekton-test-development-binding-vb9wz", "namespace": "rhn-support-rravi-tenant", "controllerKind": "SnapshotEnvironmentBinding", "name": "tekton-test-development-binding-vb9wz", "namespace": "rhn-support-rravi-tenant", "controllerKind": "SnapshotEnvironmentBinding", "name": "tekton-test-development-binding-vb9wz", "namespace": "rhn-support-rravi-tenant", "controllerKind": "SnapshotEnvironmentBinding", "name": "test-app-168233416-development-binding-5w9zl", "namespace": "skhileri-tenant", "controllerKind": "SnapshotEnvironmentBinding", "name": "test-app-168233416-development-binding-5w9zl", "namespace": "skhileri-tenant", "controllerKind": "SnapshotEnvironmentBinding", "name": "test-app-168233416-development-binding-5w9zl", "namespace": "skhileri-tenant", "controllerKind": "SnapshotEnvironmentBinding", "name": "my-app-2-development-binding-mt8dx", "namespace": "pkumari-tenant", "controllerKind": "SnapshotEnvironmentBinding", "name": "my-app-2-development-binding-mt8dx", "namespace": "pkumari-tenant", "controllerKind": "SnapshotEnvironmentBinding", "name": "my-app-2-development-binding-mt8dx", (... this goes on for many lines ..)
`

Notice the many repetitions of namespace, controllerKind, and name, across different namespaces.

This PR should fix the issue:
- Use a locally scoped log object when adding values, rather than modifying the global object
- Fix a case where the snapshot webhook logs were referencing the promotion run controller.