### PR TITLE
Avoid appending the same log keys over and over in webhooks

### DIFF
--- a/api/v1alpha1/application_webhook.go
+++ b/api/v1alpha1/application_webhook.go
@@ -55,7 +55,7 @@ var _ webhook.Validator = &Application{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Application) ValidateCreate() error {
-	applicationlog = applicationlog.WithValues("controllerKind", "Application").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	applicationlog := applicationlog.WithValues("controllerKind", "Application").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
 	applicationlog.Info("validating the create request")
 	// We use the DNS-1035 format for application names, so ensure it conforms to that specification
 	if len(validation.IsDNS1035Label(r.Name)) != 0 {
@@ -69,7 +69,7 @@ func (r *Application) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Application) ValidateUpdate(old runtime.Object) error {
-	applicationlog = applicationlog.WithValues("controllerKind", "Application").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	applicationlog := applicationlog.WithValues("controllerKind", "Application").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
 	applicationlog.Info("validating the update request")
 
 	switch old := old.(type) {

--- a/api/v1alpha1/component_webhook.go
+++ b/api/v1alpha1/component_webhook.go
@@ -61,7 +61,7 @@ var _ webhook.Validator = &Component{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Component) ValidateCreate() error {
-	componentlog = componentlog.WithValues("controllerKind", "Component").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	componentlog := componentlog.WithValues("controllerKind", "Component").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
 	componentlog.Info("validating the create request")
 
 	// We use the DNS-1035 format for component names, so ensure it conforms to that specification
@@ -91,7 +91,7 @@ func (r *Component) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Component) ValidateUpdate(old runtime.Object) error {
-	componentlog = componentlog.WithValues("controllerKind", "Component").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	componentlog := componentlog.WithValues("controllerKind", "Component").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
 	componentlog.Info("validating the update request")
 
 	switch old := old.(type) {

--- a/api/v1alpha1/environment_webhook.go
+++ b/api/v1alpha1/environment_webhook.go
@@ -54,7 +54,7 @@ var _ webhook.Validator = &Environment{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Environment) ValidateCreate() error {
-	environmentlog = environmentlog.WithValues("controllerKind", "Environment").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	environmentlog := environmentlog.WithValues("controllerKind", "Environment").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
 	environmentlog.Info("validating the create request")
 
 	// We use the DNS-1123 format for environment names, so ensure it conforms to that specification
@@ -67,7 +67,7 @@ func (r *Environment) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Environment) ValidateUpdate(old runtime.Object) error {
-	environmentlog = environmentlog.WithValues("controllerKind", "Environment").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	environmentlog := environmentlog.WithValues("controllerKind", "Environment").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
 	environmentlog.Info("validating the update request")
 
 	return r.validateIngressDomain()


### PR DESCRIPTION
The log statements from the webhook code currently look like this, due to use of a global mutable variable:

`
{"level":"info","ts":"2023-06-02T11:57:24.502877274Z","logger":"environment-resource","caller":"v1alpha1/environment_webhook.go:71","msg":"validating the update request","controllerKind":"Environment","name":"development","namespace":"e2e-demos-mitl-tenant","controllerKind":"Environment","name":"development","namespace":"e2e-demos-mitl-tenant","controllerKind":"Environment","name":"development","namespace":"spi-demos-iyei-tenant","controllerKind":"Environment","name":"development","namespace":"byoc-igsk-tenant","controllerKind":"Environment","name":"development","namespace":"spi-demos-xpei-tenant","controllerKind":"Environment","name":"development","namespace":"chains-e2e-dgpf-tenant","controllerKind":"Environment","name":"development","namespace":"e2e-demos-pttg-tenant","controllerKind":"Environment","name":"development","namespace":"chains-e2e-dgpf-tenant","controllerKind":"Environment","name":"development","namespace":"integration-e2e-tenant","controllerKind":"Environment","name":"development","namespace":"multi-comp-e2e-xzup-tenant","controllerKind":"Environment","name":"development","namespace":"multi-comp-e2e-xzup-tenant","controllerKind":"Environment","name":"development","namespace":"multi-comp-e2e-sypz-tenant","controllerKind":"Environment","name":"development", (...)
`