### PR TITLE
Add RouteName to BindingComponentStatus

### DIFF
--- a/api/v1alpha1/snapshotenvironmentbinding_types.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_types.go
@@ -132,6 +132,9 @@ type BindingComponentStatus struct {
 	// Name is the name of the component.
 	Name string `json:"name"`
 
+	// RouteName is the name of the route for the Component
+	RouteName string `json:"routeName"`
+
 	// GitOpsRepository contains the Git URL, path, branch, and most recent commit id for the component
 	GitOpsRepository BindingComponentGitOpsRepository `json:"gitopsRepository"`
 }

--- a/config/crd/bases/appstudio.redhat.com_snapshotenvironmentbindings.yaml
+++ b/config/crd/bases/appstudio.redhat.com_snapshotenvironmentbindings.yaml
@@ -338,9 +338,13 @@ spec:
                     name:
                       description: Name is the name of the component.
                       type: string
+                    routeName:
+                      description: RouteName is the name of the route for the Component
+                      type: string
                   required:
                   - gitopsRepository
                   - name
+                  - routeName
                   type: object
                 type: array
               gitopsDeployments:

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -1976,9 +1976,13 @@ spec:
                     name:
                       description: Name is the name of the component.
                       type: string
+                    routeName:
+                      description: RouteName is the name of the route for the Component
+                      type: string
                   required:
                   - gitopsRepository
                   - name
+                  - routeName
                   type: object
                 type: array
               gitopsDeployments:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHTAPBUGS-322

We need to persist the generated route name in the SEB status so that the route name remains consistent between reconciles for a SEB resource.