### PR TITLE
Change routeName in status to GeneratedRouteName

### DIFF
--- a/api/v1alpha1/snapshotenvironmentbinding_types.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_types.go
@@ -133,7 +133,7 @@ type BindingComponentStatus struct {
 	Name string `json:"name"`
 
 	// GeneratedRouteName is the name of the route that was generated for the Component, if a Route was generated.
-	GeneratedRouteName string `json:"routeName,omitempty"`
+	GeneratedRouteName string `json:"generatedRouteName,omitempty"`
 
 	// GitOpsRepository contains the Git URL, path, branch, and most recent commit id for the component
 	GitOpsRepository BindingComponentGitOpsRepository `json:"gitopsRepository"`

--- a/api/v1alpha1/snapshotenvironmentbinding_types.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_types.go
@@ -132,8 +132,8 @@ type BindingComponentStatus struct {
 	// Name is the name of the component.
 	Name string `json:"name"`
 
-	// RouteName is the name of the route for the Component
-	RouteName string `json:"routeName"`
+	// GeneratedRouteName is the name of the route that was generated for the Component, if a Route was generated.
+	GeneratedRouteName string `json:"routeName,omitempty"`
 
 	// GitOpsRepository contains the Git URL, path, branch, and most recent commit id for the component
 	GitOpsRepository BindingComponentGitOpsRepository `json:"gitopsRepository"`

--- a/config/crd/bases/appstudio.redhat.com_snapshotenvironmentbindings.yaml
+++ b/config/crd/bases/appstudio.redhat.com_snapshotenvironmentbindings.yaml
@@ -339,12 +339,12 @@ spec:
                       description: Name is the name of the component.
                       type: string
                     routeName:
-                      description: RouteName is the name of the route for the Component
+                      description: GeneratedRouteName is the name of the route that
+                        was generated for the Component, if a Route was generated.
                       type: string
                   required:
                   - gitopsRepository
                   - name
-                  - routeName
                   type: object
                 type: array
               gitopsDeployments:

--- a/config/crd/bases/appstudio.redhat.com_snapshotenvironmentbindings.yaml
+++ b/config/crd/bases/appstudio.redhat.com_snapshotenvironmentbindings.yaml
@@ -295,6 +295,10 @@ spec:
                 items:
                   description: BindingComponentStatus contains the status of the components
                   properties:
+                    generatedRouteName:
+                      description: GeneratedRouteName is the name of the route that
+                        was generated for the Component, if a Route was generated.
+                      type: string
                     gitopsRepository:
                       description: GitOpsRepository contains the Git URL, path, branch,
                         and most recent commit id for the component
@@ -337,10 +341,6 @@ spec:
                       type: object
                     name:
                       description: Name is the name of the component.
-                      type: string
-                    routeName:
-                      description: GeneratedRouteName is the name of the route that
-                        was generated for the Component, if a Route was generated.
                       type: string
                   required:
                   - gitopsRepository

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -1977,12 +1977,12 @@ spec:
                       description: Name is the name of the component.
                       type: string
                     routeName:
-                      description: RouteName is the name of the route for the Component
+                      description: GeneratedRouteName is the name of the route that
+                        was generated for the Component, if a Route was generated.
                       type: string
                   required:
                   - gitopsRepository
                   - name
-                  - routeName
                   type: object
                 type: array
               gitopsDeployments:

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -1933,6 +1933,10 @@ spec:
                 items:
                   description: BindingComponentStatus contains the status of the components
                   properties:
+                    generatedRouteName:
+                      description: GeneratedRouteName is the name of the route that
+                        was generated for the Component, if a Route was generated.
+                      type: string
                     gitopsRepository:
                       description: GitOpsRepository contains the Git URL, path, branch,
                         and most recent commit id for the component
@@ -1975,10 +1979,6 @@ spec:
                       type: object
                     name:
                       description: Name is the name of the component.
-                      type: string
-                    routeName:
-                      description: GeneratedRouteName is the name of the route that
-                        was generated for the Component, if a Route was generated.
                       type: string
                   required:
                   - gitopsRepository


### PR DESCRIPTION
We don't need to store the route name in the status when we don't generate the route name, so renaming it to `GeneratedRouteName` makes sense. Likewise, since we only store the route name when it's generated, the `omitEmpty` tag should be added as well.