### PR TITLE
Use package-scoped client from manager for SnapshotEnvBinding webhook

### DIFF
--- a/api/v1alpha1/snapshotenvironmentbinding_webhook.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_webhook.go
@@ -31,75 +31,58 @@ import (
 // log is for logging in this package.
 var snapshotenvironmentbindinglog = logf.Log.WithName("snapshotenvironmentbinding-resource")
 
-func (r *snapshotEnvironmentBindingWebhookHandler) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	r.Client = mgr.GetClient()
+var snapshotEnvironmentBindingClientFromManager client.Client
+
+func (r *SnapshotEnvironmentBinding) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	snapshotEnvironmentBindingClientFromManager = mgr.GetClient()
+
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&SnapshotEnvironmentBinding{}).
-		WithValidator(r).
+		For(r).
 		Complete()
 }
 
 //+kubebuilder:webhook:path=/mutate-appstudio-redhat-com-v1alpha1-snapshotenvironmentbinding,mutating=true,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=snapshotenvironmentbindings,verbs=create;update,versions=v1alpha1,name=msnapshotenvironmentbinding.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomDefaulter = &snapshotEnvironmentBindingWebhookHandler{}
+var _ webhook.Defaulter = &SnapshotEnvironmentBinding{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (h *snapshotEnvironmentBindingWebhookHandler) Default(ctx context.Context, obj runtime.Object) error {
-	binding, ok := obj.(*SnapshotEnvironmentBinding)
-	if !ok {
-		return fmt.Errorf("runtime object is not of type SnapshotEnvironmentBinding")
-	}
-
-	snapshotenvironmentbindinglog := snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", binding.Name).WithValues("namespace", binding.Namespace)
-	snapshotenvironmentbindinglog.Info("default", "name", binding.Name)
-
-	return nil
+func (r *SnapshotEnvironmentBinding) Default() {
+	snapshotenvironmentbindinglog := snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
+	snapshotenvironmentbindinglog.Info("default", "name", r.Name)
 }
 
 // change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-snapshotenvironmentbinding,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=snapshotenvironmentbindings,verbs=create;update,versions=v1alpha1,name=vsnapshotenvironmentbinding.kb.io,admissionReviewVersions=v1
-type snapshotEnvironmentBindingWebhookHandler struct {
-	client.Client
-}
+//+kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-snapshotenvironmentbinding,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=snapshotenvironmentbindings,verbs=create;update,versions=v1alpha1,name=vsnapshotenvironmentbinding.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &snapshotEnvironmentBindingWebhookHandler{}
+var _ webhook.Validator = &SnapshotEnvironmentBinding{}
 
-func (h *snapshotEnvironmentBindingWebhookHandler) ValidateCreate(ctx context.Context, obj runtime.Object) error {
-	binding, ok := obj.(*SnapshotEnvironmentBinding)
-	if !ok {
-		return fmt.Errorf("runtime object is not of type SnapshotEnvironmentBinding")
-	}
-
-	snapshotenvironmentbindinglog := snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", binding.Name).WithValues("namespace", binding.Namespace)
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *SnapshotEnvironmentBinding) ValidateCreate() error {
+	snapshotenvironmentbindinglog := snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
 	snapshotenvironmentbindinglog.Info("validating create")
 
-	if err := h.validateSEB(binding); err != nil {
+	if err := validateSEB(r); err != nil {
 		return fmt.Errorf("invalid SnapshotEnvironmentBinding: %v", err)
 	}
 
 	return nil
 }
 
-func (h *snapshotEnvironmentBindingWebhookHandler) ValidateUpdate(ctx context.Context, obj, oldObj runtime.Object) error {
-	newBinding, ok := obj.(*SnapshotEnvironmentBinding)
-	if !ok {
-		return fmt.Errorf("runtime object is not of type SnapshotEnvironmentBinding")
-	}
-
-	snapshotenvironmentbindinglog := snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", newBinding.Name).WithValues("namespace", newBinding.Namespace)
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *SnapshotEnvironmentBinding) ValidateUpdate(old runtime.Object) error {
+	snapshotenvironmentbindinglog := snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
 	snapshotenvironmentbindinglog.Info("validating update")
 
-	switch old := oldObj.(type) {
+	switch old := old.(type) {
 	case *SnapshotEnvironmentBinding:
-		if !reflect.DeepEqual(newBinding.Spec.Application, old.Spec.Application) {
-			return fmt.Errorf("application field cannot be updated to %+v", newBinding.Spec.Application)
+		if !reflect.DeepEqual(r.Spec.Application, old.Spec.Application) {
+			return fmt.Errorf("application field cannot be updated to %+v", r.Spec.Application)
 		}
 
-		if !reflect.DeepEqual(newBinding.Spec.Environment, old.Spec.Environment) {
-			return fmt.Errorf("environment field cannot be updated to %+v", newBinding.Spec.Environment)
+		if !reflect.DeepEqual(r.Spec.Environment, old.Spec.Environment) {
+			return fmt.Errorf("environment field cannot be updated to %+v", r.Spec.Environment)
 		}
-
-		if err := h.validateSEB(newBinding); err != nil {
+		if err := validateSEB(r); err != nil {
 			return fmt.Errorf("invalid SnapshotEnvironmentBinding: %v", err)
 		}
 
@@ -108,26 +91,26 @@ func (h *snapshotEnvironmentBindingWebhookHandler) ValidateUpdate(ctx context.Co
 	}
 
 	return nil
-
 }
 
-func (h *snapshotEnvironmentBindingWebhookHandler) ValidateDelete(ctx context.Context, obj runtime.Object) error {
-	binding, ok := obj.(*SnapshotEnvironmentBinding)
-	if !ok {
-		return fmt.Errorf("runtime object is not of type SnapshotEnvironmentBinding")
-	}
-
-	snapshotenvironmentbindinglog := snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", binding.Name).WithValues("namespace", binding.Namespace)
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *SnapshotEnvironmentBinding) ValidateDelete() error {
+	snapshotenvironmentbindinglog := snapshotenvironmentbindinglog.WithValues("controllerKind", "SnapshotEnvironmentBinding").WithValues("name", r.Name).WithValues("namespace", r.Namespace)
 	snapshotenvironmentbindinglog.Info("validating delete")
+
 	return nil
 }
 
-func (h *snapshotEnvironmentBindingWebhookHandler) validateSEB(newBinding *SnapshotEnvironmentBinding) error {
+func validateSEB(newBinding *SnapshotEnvironmentBinding) error {
+
+	if snapshotEnvironmentBindingClientFromManager == nil {
+		return fmt.Errorf("webhook not initialized")
+	}
 
 	// Retrieve the list of existing SnapshotEnvironmentBindings from the namespace
 	existingSEBs := SnapshotEnvironmentBindingList{}
 
-	if err := h.Client.List(context.Background(), &existingSEBs, &client.ListOptions{Namespace: newBinding.Namespace}); err != nil {
+	if err := snapshotEnvironmentBindingClientFromManager.List(context.Background(), &existingSEBs, &client.ListOptions{Namespace: newBinding.Namespace}); err != nil {
 		return fmt.Errorf("failed to list existing SnapshotEnvironmentBindings: %v", err)
 	}
 

--- a/api/v1alpha1/snapshotenvironmentbinding_webhook_test.go
+++ b/api/v1alpha1/snapshotenvironmentbinding_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -115,8 +114,6 @@ func TestSnapshotEnvironmentBindingValidateUpdateWebhook(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
-			wh := &snapshotEnvironmentBindingWebhookHandler{}
-
 			objects := make([]runtime.Object, len(test.existingSEBs))
 			for i, seb := range test.existingSEBs {
 				objects[i] = &seb
@@ -134,8 +131,9 @@ func TestSnapshotEnvironmentBindingValidateUpdateWebhook(t *testing.T) {
 				WithRuntimeObjects(objects...).
 				Build()
 
-			wh.Client = fakeClient
-			actualError := wh.ValidateUpdate(ctx, &test.testData, &originalBinding)
+			snapshotEnvironmentBindingClientFromManager = fakeClient
+
+			actualError := test.testData.ValidateUpdate(&originalBinding)
 
 			if test.expectedError == "" {
 				assert.Nil(t, actualError)
@@ -198,8 +196,6 @@ func TestSnapshotEnvironmentBindingValidateCreateWebhook(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
 
-			wh := &snapshotEnvironmentBindingWebhookHandler{}
-
 			objects := make([]runtime.Object, len(test.existingSEBs))
 			for i, seb := range test.existingSEBs {
 				objects[i] = &seb
@@ -217,9 +213,9 @@ func TestSnapshotEnvironmentBindingValidateCreateWebhook(t *testing.T) {
 				WithRuntimeObjects(objects...).
 				Build()
 
-			wh.Client = fakeClient
+			snapshotEnvironmentBindingClientFromManager = fakeClient
 
-			actualError := wh.ValidateCreate(context.Background(), &test.testData)
+			actualError := test.testData.ValidateCreate()
 
 			if test.expectedError == "" {
 				assert.Nil(t, actualError)

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -110,7 +110,7 @@ var _ = BeforeSuite(func() {
 	err = (&Snapshot{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&snapshotEnvironmentBindingWebhookHandler{}).SetupWebhookWithManager(mgr)
+	err = (&SnapshotEnvironmentBinding{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&PromotionRun{}).SetupWebhookWithManager(mgr)

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -214,3 +214,23 @@ webhooks:
     resources:
     - snapshots
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-snapshotenvironmentbinding
+  failurePolicy: Fail
+  name: vsnapshotenvironmentbinding.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - snapshotenvironmentbindings
+  sideEffects: None


### PR DESCRIPTION
I hit issues when trying to setup the new SnapshotEnvironmentBinding webhook code in `appstudio-controller` component, in managed-gitops:
- When trying to call `SetupWebhookWithManager` from appstudio-controller, this error message occurs: `(&applicationv1alpha1.SnapshotEnvironmentBinding{}).SetupWebhookWithManager undefined (type *"github.com/redhat-appstudio/application-api/api/v1alpha1".SnapshotEnvironmentBinding has no field or method SetupWebhookWithManager)`
- Instead, I've tweaked the `SnapshotEnvironmentBinding` webhook code to use a k8s client at package scope.