### PR TITLE
[RHTAPBUGS-529] Allow non-url GitSource changes in Components

### DIFF
--- a/api/v1alpha1/component_webhook.go
+++ b/api/v1alpha1/component_webhook.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"reflect"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -105,7 +104,7 @@ func (r *Component) ValidateUpdate(old runtime.Object) error {
 			return fmt.Errorf(ApplicationNameUpdateError, r.Spec.Application)
 		}
 
-		if r.Spec.Source.GitSource != nil && old.Spec.Source.GitSource != nil && !reflect.DeepEqual(*(r.Spec.Source.GitSource), *(old.Spec.Source.GitSource)) {
+		if r.Spec.Source.GitSource != nil && old.Spec.Source.GitSource != nil && (r.Spec.Source.GitSource.URL != old.Spec.Source.GitSource.URL) {
 			return fmt.Errorf(GitSourceUpdateError, *(r.Spec.Source.GitSource))
 		}
 	default:

--- a/api/v1alpha1/component_webhook_unit_test.go
+++ b/api/v1alpha1/component_webhook_unit_test.go
@@ -193,7 +193,7 @@ func TestComponentUpdateValidatingWebhook(t *testing.T) {
 			},
 		},
 		{
-			name: "git src cannot be changed",
+			name: "git src url cannot be changed",
 			err: fmt.Errorf(GitSourceUpdateError, GitSource{
 				URL:     "http://link1",
 				Context: "context",
@@ -207,6 +207,24 @@ func TestComponentUpdateValidatingWebhook(t *testing.T) {
 							GitSource: &GitSource{
 								URL:     "http://link1",
 								Context: "context",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "non-url git source can be changed",
+			updateComp: Component{
+				Spec: ComponentSpec{
+					ComponentName: "component",
+					Application:   "application",
+					Source: ComponentSource{
+						ComponentSourceUnion: ComponentSourceUnion{
+							GitSource: &GitSource{
+								Context:       "new-context",
+								DevfileURL:    "https://new-devfile-url",
+								DockerfileURL: "https://new-dockerfile-url",
 							},
 						},
 					},


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/RHTAPBUGS-529

Updates the Component webhook to only block GitSource updates that modify the URL. Other Git source changes, like context or devfileURL, will be allowed.