### PR TITLE
Add omitempty to EnvironmentConfiguration.env

### DIFF
--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -152,7 +152,7 @@ type KubernetesClusterCredentials struct {
 // Component/Application GitOps repository resources.
 type EnvironmentConfiguration struct {
 	// Env is an array of standard environment vairables
-	Env []EnvVarPair `json:"env"`
+	Env []EnvVarPair `json:"env,omitempty"`
 
 	// Target is used to reference a DeploymentTargetClaim for a target Environment.
 	// The Environment controller uses the referenced DeploymentTargetClaim to access its bounded

--- a/config/crd/bases/appstudio.redhat.com_environments.yaml
+++ b/config/crd/bases/appstudio.redhat.com_environments.yaml
@@ -76,8 +76,6 @@ spec:
                     required:
                     - deploymentTargetClaim
                     type: object
-                required:
-                - env
                 type: object
               deploymentStrategy:
                 description: DeploymentStrategy is the promotion strategy for the

--- a/manifests/application-api-customresourcedefinitions.yaml
+++ b/manifests/application-api-customresourcedefinitions.yaml
@@ -1292,8 +1292,6 @@ spec:
                     required:
                     - deploymentTargetClaim
                     type: object
-                required:
-                - env
                 type: object
               deploymentStrategy:
                 description: DeploymentStrategy is the promotion strategy for the


### PR DESCRIPTION
This PR adds `omitempty` to the `EnvironmentConfiguration.Env` field for the Environment CR. Env being a required field was raised on slack by @skabashnyuk, and I see no reason for it to be required?

CC @maysunfaisal @jgwest for awareness, in case there's a reason it's required.

See more: https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1696254156547549